### PR TITLE
Refresh Genie landing copy and layout

### DIFF
--- a/genie.html
+++ b/genie.html
@@ -5,37 +5,177 @@
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <title>genie</title>
     <style>
-        :root { --accent: #2a5bd7; }
-        body, html { margin: 0; padding: 0; font-family: -apple-system, BlinkMacSystemFont, "Helvetica Neue", Arial, sans-serif; background: linear-gradient(180deg, #ffffff, #f0f7ff); color: #333; }
-        header { display: flex; justify-content: space-between; align-items: center; padding: 20px 40px; position: sticky; top: 0; backdrop-filter: blur(12px); background: rgba(255, 255, 255, 0.85); border-bottom: 1px solid rgba(42, 91, 215, 0.08); z-index: 10; }
-        nav a { margin-left: 20px; text-decoration: none; color: #555; font-size: 14px; }
-        nav a:hover { color: var(--accent); }
-        .hero { padding: 120px 20px 100px; text-align: center; position: relative; }
-        .hero::before { content: ""; position: absolute; inset: 0; background: radial-gradient(circle at top, rgba(42, 91, 215, 0.18), transparent 55%); z-index: -1; }
-        h1 { font-size: 64px; margin: 0; text-transform: lowercase; }
-        h2 { font-size: 32px; margin-bottom: 20px; text-transform: lowercase; }
+        :root { --accent: #2a5bd7; --accent-dark: #1f3c9a; }
+        body, html {
+            margin: 0;
+            padding: 0;
+            font-family: -apple-system, BlinkMacSystemFont, "Helvetica Neue", Arial, sans-serif;
+            background: linear-gradient(180deg, #ffffff, #f0f7ff);
+            color: #333;
+        }
+        header {
+            position: sticky;
+            top: 0;
+            z-index: 10;
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            padding: 18px 40px;
+            background: linear-gradient(120deg, rgba(42, 91, 215, 0.95), rgba(30, 54, 150, 0.88));
+            color: #f5f7ff;
+            border-bottom: 1px solid rgba(255, 255, 255, 0.15);
+            box-shadow: 0 18px 35px rgba(20, 52, 145, 0.25);
+        }
+        header::after {
+            content: "";
+            position: absolute;
+            inset: auto 40px -12px 40px;
+            height: 4px;
+            background: linear-gradient(90deg, rgba(255,255,255,0.35), rgba(255,255,255,0));
+            border-radius: 999px;
+        }
+        .logo {
+            font-weight: 700;
+            letter-spacing: 1px;
+            text-transform: lowercase;
+        }
+        nav a {
+            margin-left: 24px;
+            text-decoration: none;
+            color: #f7f8ff;
+            font-size: 14px;
+            font-weight: 600;
+            letter-spacing: 0.4px;
+        }
+        nav a:hover { color: #dbe7ff; }
+        .hero {
+            padding: 120px 20px 110px;
+            text-align: center;
+            position: relative;
+        }
+        .hero::before {
+            content: "";
+            position: absolute;
+            inset: 0;
+            background: radial-gradient(circle at top, rgba(42, 91, 215, 0.18), transparent 55%);
+            z-index: -2;
+        }
+        .hero::after {
+            content: "";
+            position: absolute;
+            top: 60px;
+            right: 18%;
+            width: 220px;
+            height: 220px;
+            background: radial-gradient(circle, rgba(110, 155, 255, 0.55), rgba(110, 155, 255, 0));
+            filter: blur(8px);
+            z-index: -1;
+        }
+        h1 {
+            font-size: 64px;
+            margin: 0;
+            text-transform: lowercase;
+        }
+        h2 {
+            font-size: 32px;
+            margin-bottom: 20px;
+            text-transform: lowercase;
+        }
         p { max-width: 680px; margin: 20px auto; line-height: 1.7; }
-        .cta { display: inline-block; margin-top: 30px; padding: 14px 36px; border-radius: 999px; background: var(--accent); color: #fff; text-decoration: none; font-size: 16px; box-shadow: 0 15px 35px rgba(42, 91, 215, 0.25); transition: transform 0.2s ease, box-shadow 0.2s ease; }
-        .cta:hover { transform: translateY(-2px); box-shadow: 0 20px 45px rgba(42, 91, 215, 0.35); }
-        .value-tag { display: inline-block; margin-top: 16px; padding: 6px 16px; border-radius: 999px; background: rgba(42, 91, 215, 0.1); color: var(--accent); font-size: 14px; letter-spacing: 0.5px; text-transform: uppercase; }
-        .contact-note { margin-top: 32px; display: inline-block; }
-        .contact-note a { color: inherit; text-decoration: underline; }
-        section { padding: 80px 20px; text-align: center; }
-        .features { display: grid; grid-template-columns: repeat(auto-fit, minmax(160px, 1fr)); gap: 24px; margin-top: 40px; max-width: 720px; margin-left: auto; margin-right: auto; }
-        .feature { padding: 24px; border-radius: 16px; background: #fff; border: 1px solid rgba(42, 91, 215, 0.15); box-shadow: 0 12px 30px rgba(21, 72, 170, 0.08); color: #1d3c8a; font-weight: 600; letter-spacing: 0.5px; text-transform: uppercase; font-size: 13px; }
-        .feature span { display: block; margin-top: 12px; font-size: 14px; text-transform: none; color: #4a5d85; font-weight: 400; }
-        .report-cards { display: grid; grid-template-columns: repeat(auto-fit, minmax(240px, 1fr)); gap: 30px; max-width: 960px; margin: 50px auto 0; }
-        .report-card { padding: 32px; border-radius: 20px; background: linear-gradient(160deg, rgba(42, 91, 215, 0.12), rgba(255, 255, 255, 0.7)); box-shadow: 0 18px 45px rgba(13, 57, 156, 0.08); text-align: left; }
-        .report-card h3 { margin-top: 0; font-size: 22px; text-transform: none; color: #1d3c8a; }
-        .report-card p { margin: 12px 0 0; font-size: 15px; color: #4a5d85; }
-        .report-icon { font-size: 32px; margin-bottom: 14px; }
-        .banner { max-width: 720px; margin: 0 auto; padding: 24px 32px; background: rgba(42, 91, 215, 0.08); border-radius: 18px; color: #1d3c8a; font-weight: 600; }
-        footer { padding: 40px; text-align: center; font-size: 12px; color: #999; }
+        .cta {
+            display: inline-block;
+            margin-top: 32px;
+            padding: 14px 36px;
+            border-radius: 999px;
+            background: var(--accent);
+            color: #fff;
+            text-decoration: none;
+            font-size: 16px;
+            box-shadow: 0 18px 38px rgba(42, 91, 215, 0.28);
+            transition: transform 0.2s ease, box-shadow 0.2s ease;
+        }
+        .cta:hover { transform: translateY(-2px); box-shadow: 0 22px 48px rgba(42, 91, 215, 0.38); }
+        section { padding: 80px 20px; text-align: center; position: relative; }
+        .features {
+            display: grid;
+            grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+            gap: 18px;
+            margin-top: 44px;
+            max-width: 720px;
+            margin-left: auto;
+            margin-right: auto;
+        }
+        .feature {
+            padding: 22px;
+            border-radius: 16px;
+            background: #fff;
+            border: 1px solid rgba(42, 91, 215, 0.12);
+            color: #1d3c8a;
+            font-weight: 600;
+            letter-spacing: 0.5px;
+            text-transform: uppercase;
+            font-size: 13px;
+        }
+        .report-grid {
+            display: grid;
+            grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+            gap: 26px;
+            max-width: 960px;
+            margin: 50px auto 0;
+        }
+        .report-item {
+            padding: 30px;
+            border-radius: 20px;
+            background: linear-gradient(160deg, rgba(42, 91, 215, 0.1), rgba(255, 255, 255, 0.85));
+            box-shadow: 0 18px 45px rgba(13, 57, 156, 0.08);
+            text-align: left;
+        }
+        .report-item h3 {
+            margin: 0 0 10px;
+            font-size: 20px;
+            text-transform: none;
+            color: #1d3c8a;
+        }
+        .report-item p {
+            margin: 0;
+            font-size: 14px;
+            color: #4a5d85;
+            line-height: 1.6;
+        }
+        .report-icon {
+            font-size: 30px;
+            margin-bottom: 16px;
+        }
+        .pattern-band {
+            position: absolute;
+            top: -40px;
+            left: 50%;
+            transform: translateX(-50%);
+            width: min(90%, 960px);
+            height: 140px;
+            background: linear-gradient(135deg, rgba(42, 91, 215, 0.12), rgba(42, 91, 215, 0));
+            border-radius: 28px;
+            z-index: -3;
+        }
+        footer {
+            padding: 40px;
+            text-align: center;
+            font-size: 12px;
+            color: #999;
+        }
+        @media (max-width: 640px) {
+            header {
+                padding: 16px 24px;
+            }
+            nav a { margin-left: 16px; }
+            h1 { font-size: 46px; }
+            h2 { font-size: 26px; }
+        }
     </style>
 </head>
 <body>
     <header>
-        <div>genie</div>
+        <div class="logo">genie</div>
         <nav>
             <a href="#about">about</a>
             <a href="#report">report</a>
@@ -44,47 +184,50 @@
     </header>
     <div class="hero">
         <h1>genie</h1>
-        <p>Genie partners with small business leaders to uncover the smart, simple systems that move the needle. In two short sessions we map out the tools, automations, and AI plays that save time, cut costs, simplify operations, and unlock your next wave of growth.</p>
-        <div class="value-tag">$750 strategy report · yours free</div>
+        <p>Genie works with small businesses to uncover the smart, simple systems that move the needle. Meet with us to map out the tools, automations, and AI plays that save time, cut costs, simplify operations, and unlock your next wave of growth.</p>
         <a class="cta" href="https://calendly.com/kavishpsucamp/30min" target="_blank" rel="noopener">get started</a>
     </div>
     <section id="about">
-        <div class="banner">two conversations. one tailored action plan to help your team work smarter this quarter.</div>
+        <div class="pattern-band"></div>
+        <h2>how we help</h2>
         <div class="features">
-            <div class="feature">save time<span>eliminate manual busywork with the right no-code stack</span></div>
-            <div class="feature">cut costs<span>automate repeatable workflows and trim subscription sprawl</span></div>
-            <div class="feature">simplify ops<span>connect your tools so data flows cleanly end-to-end</span></div>
-            <div class="feature">level up strategy<span>translate operational wins into sharper positioning and offers</span></div>
-            <div class="feature">amplify marketing<span>build smarter campaigns fueled by insights, not guesswork</span></div>
+            <div class="feature">save time</div>
+            <div class="feature">cut costs</div>
+            <div class="feature">simplify ops</div>
+            <div class="feature">plan growth</div>
         </div>
     </section>
     <section id="report">
         <h2>what's inside your report</h2>
-        <div class="report-cards">
-            <div class="report-card">
+        <div class="report-grid">
+            <div class="report-item">
                 <div class="report-icon">🧭</div>
-                <h3>Operational playbook</h3>
-                <p>Clear prioritised recommendations on the software and workflows that shave hours off recurring tasks, protect margins, and create the headroom to scale.</p>
+                <h3>core systems</h3>
+                <p>See where software can shoulder the work across operations, finance, HR, and every team that keeps you moving.</p>
             </div>
-            <div class="report-card">
+            <div class="report-item">
                 <div class="report-icon">🤖</div>
-                <h3>AI advantage roadmap</h3>
-                <p>Everyone’s talking about AI—your report makes it actionable. Discover automations, copilots, and prompts tailored to the way your team sells, supports, and delivers.</p>
+                <h3>ai accelerators</h3>
+                <p>Pinpoint the copilots, prompts, and models that deliver leverage across the same workflows without extra headcount.</p>
             </div>
-            <div class="report-card">
+            <div class="report-item">
+                <div class="report-icon">⚙️</div>
+                <h3>automation plays</h3>
+                <p>Highlight the handoffs and approvals ready for streamlined, no-code automation so your team stays focused on impact.</p>
+            </div>
+            <div class="report-item">
                 <div class="report-icon">📈</div>
-                <h3>Growth acceleration kit</h3>
-                <p>Insights that tie operational gains to sharper strategy, smarter marketing, and customer experiences that keep people coming back.</p>
+                <h3>growth roadmap</h3>
+                <p>Connect today’s wins to the next wave of growth with clear opportunities, sequencing, and milestones to track progress.</p>
             </div>
         </div>
     </section>
     <section id="contact">
         <h2>ready for your custom brief?</h2>
-        <p>Grab a slot and we’ll meet you where you are—whether you’re modernising operations, experimenting with AI, or planning your next growth sprint.</p>
+        <p>Grab a slot and we’ll meet you where you are—whether you’re modernising operations, exploring AI, or planning how you will grow next.</p>
         <a class="cta" href="https://calendly.com/kavishpsucamp/30min" target="_blank" rel="noopener">book a 30-min intro</a>
-        <p class="value-tag contact-note">have a question? <a href="mailto:kavishs@sas.upenn.edu">kavishs@sas.upenn.edu</a></p>
+        <p style="margin-top: 32px; font-weight: 600; color: #1d3c8a;">email: <a href="mailto:kavishs@sas.upenn.edu" style="color: inherit; text-decoration: underline;">kavishs@sas.upenn.edu</a></p>
     </section>
     <footer>&copy; 2025 genie</footer>
 </body>
 </html>
-


### PR DESCRIPTION
## Summary
- refresh the hero copy to invite meetings with small businesses and remove the outdated pricing badge
- streamline the feature highlights and report categories to focus on software, AI, automation, and growth opportunities
- add color and subtle decorative accents to the navigation and layout while simplifying the contact details

## Testing
- not run (static content change)


------
https://chatgpt.com/codex/tasks/task_e_68ca6b70fcc4832f9c8238fa3d1190ee