### PR TITLE
Refresh demo apps and experiment builder

### DIFF
--- a/competitors.html
+++ b/competitors.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Genie | Competitor Radar</title>
+    <title>Genie | Competitors</title>
     <script>
       tailwind.config = {
         theme: {
@@ -14,7 +14,6 @@
             },
             colors: {
               night: '#050505',
-              surface: 'rgba(255,255,255,0.04)',
             },
           },
         },
@@ -25,10 +24,15 @@
       rel="stylesheet"
       href="https://fonts.googleapis.com/css2?family=Great+Vibes&family=Inter:wght@300;400;500;600;700&display=swap"
     />
+    <style>
+      body {
+        background: #030303;
+      }
+    </style>
   </head>
   <body class="min-h-screen bg-night text-white font-sans">
-    <div class="min-h-screen px-6 md:px-12 pb-16">
-      <header class="py-8 flex items-start justify-between">
+    <div class="min-h-screen flex flex-col px-6 md:px-12 py-10">
+      <header class="flex items-start justify-between">
         <div class="space-y-4">
           <button
             onclick="window.location.href='demo.html'"
@@ -39,135 +43,127 @@
               <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M15 19l-7-7 7-7" />
             </svg>
           </button>
-          <div class="text-4xl font-script tracking-wide">genie</div>
+          <div class="text-4xl font-script tracking-wide italic">genie</div>
         </div>
         <div class="text-right">
-          <p class="uppercase tracking-[0.35em] text-xs text-white/50">Suit &amp; Thai Restaurant</p>
-          <p class="text-sm text-white/60">Competitor radar</p>
+          <p class="uppercase tracking-[0.4em] text-xs text-white/60">your AI business advisor</p>
         </div>
       </header>
 
-      <main class="space-y-12">
+      <main class="flex-1 py-10 flex flex-col gap-12">
         <section class="max-w-4xl">
-          <p class="text-sm uppercase tracking-[0.4em] text-white/40">Context</p>
-          <h1 class="mt-4 text-5xl font-light">Seattle Thai dining landscape</h1>
-          <p class="mt-6 text-lg text-white/60 leading-relaxed">
-            Genie benchmarks Suit &amp; Thai against neighborhood favorites. Signals pull from Google reviews, social chatter, delivery platforms,
-            and reservation data. The goal is awareness — we track but don't overreact.
-          </p>
+          <h1 class="text-5xl md:text-6xl font-light">Competitors</h1>
+          <p class="mt-3 text-sm uppercase tracking-[0.5em] text-white/40">spotlight</p>
         </section>
 
-        <section class="grid gap-6 xl:grid-cols-3">
-          <article class="rounded-3xl border border-white/10 bg-surface p-6 space-y-4">
-            <header class="flex items-center justify-between">
-              <div>
-                <p class="text-xs uppercase tracking-widest text-white/40">Wallingford</p>
-                <h2 class="text-2xl font-light text-white">Jai Thai</h2>
-              </div>
-              <span class="rounded-full border border-white/20 px-3 py-1 text-xs text-white/70">Watch</span>
-            </header>
-            <p class="text-sm text-white/70 leading-relaxed">
-              Launching late-night happy hour with live DJs. Google rating 4.2 ★ (1.1k reviews). Paid social spend estimated $900 this month.
-            </p>
-            <ul class="space-y-2 text-xs uppercase tracking-widest text-white/40">
-              <li class="flex justify-between text-white/70">
-                <span>Menu highlight</span>
-                <span class="text-white">Khao soi w/ tofu</span>
-              </li>
-              <li class="flex justify-between text-white/70">
-                <span>Delivery ETA</span>
-                <span class="text-white">32 min avg</span>
-              </li>
-              <li class="flex justify-between text-white/70">
-                <span>Social growth</span>
-                <span class="text-white">+7% followers 30d</span>
-              </li>
-            </ul>
-            <p class="text-xs text-white/50">Action: monitor crossover on Capitol Hill late-night orders.</p>
-          </article>
-
-          <article class="rounded-3xl border border-white/10 bg-surface p-6 space-y-4">
-            <header class="flex items-center justify-between">
-              <div>
-                <p class="text-xs uppercase tracking-widest text-white/40">University District</p>
-                <h2 class="text-2xl font-light text-white">Thai Tom</h2>
-              </div>
-              <span class="rounded-full border border-white/20 px-3 py-1 text-xs text-white/70">Benchmark</span>
-            </header>
-            <p class="text-sm text-white/70 leading-relaxed">
-              Lines out the door most evenings. Google rating 4.6 ★ (2.7k reviews). Earned 15 local press mentions in past 12 months.
-            </p>
-            <ul class="space-y-2 text-xs uppercase tracking-widest text-white/40">
-              <li class="flex justify-between text-white/70">
-                <span>Menu highlight</span>
-                <span class="text-white">Spicy pad thai</span>
-              </li>
-              <li class="flex justify-between text-white/70">
-                <span>Delivery ETA</span>
-                <span class="text-white">Pickup only</span>
-              </li>
-              <li class="flex justify-between text-white/70">
-                <span>Social growth</span>
-                <span class="text-white">Stable</span>
-              </li>
-            </ul>
-            <p class="text-xs text-white/50">Action: emphasize comfortable dine-in experience and reservations.</p>
-          </article>
-
-          <article class="rounded-3xl border border-white/10 bg-surface p-6 space-y-4">
-            <header class="flex items-center justify-between">
-              <div>
-                <p class="text-xs uppercase tracking-widest text-white/40">Capitol Hill</p>
-                <h2 class="text-2xl font-light text-white">Pinto Bistro</h2>
-              </div>
-              <span class="rounded-full border border-white/20 px-3 py-1 text-xs text-white/70">Note</span>
-            </header>
-            <p class="text-sm text-white/70 leading-relaxed">
-              Recently refreshed interiors and added craft cocktail program. Google rating 4.5 ★ (680 reviews). TikTok impressions up 22% WoW.
-            </p>
-            <ul class="space-y-2 text-xs uppercase tracking-widest text-white/40">
-              <li class="flex justify-between text-white/70">
-                <span>Menu highlight</span>
-                <span class="text-white">Crispy garlic chicken</span>
-              </li>
-              <li class="flex justify-between text-white/70">
-                <span>Delivery ETA</span>
-                <span class="text-white">38 min avg</span>
-              </li>
-              <li class="flex justify-between text-white/70">
-                <span>Social growth</span>
-                <span class="text-white">+3 pop-ups scheduled</span>
-              </li>
-            </ul>
-            <p class="text-xs text-white/50">Action: highlight Suit &amp; Thai's patio and cocktails in upcoming content.</p>
-          </article>
-        </section>
-
-        <section class="rounded-3xl border border-white/10 bg-surface p-8 space-y-6">
-          <header class="flex flex-wrap items-center justify-between gap-4">
-            <div>
-              <h2 class="text-3xl font-light">Share of Voice</h2>
-              <p class="text-sm text-white/50">Rolling 30 days across Google, Instagram, TikTok, and Yelp</p>
+        <section class="grid gap-6 md:grid-cols-3">
+          <div class="rounded-[28px] border border-white/10 bg-white/5 p-6 backdrop-blur flex flex-col">
+            <div class="flex items-center justify-between text-xs uppercase tracking-[0.35em] text-white/60">
+              <span>Thai Tom</span>
+              <span class="inline-flex h-9 w-9 items-center justify-center rounded-2xl bg-white/15 text-white/80">
+                <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                  <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M12 6l8 4-8 4-8-4 8-4z" />
+                </svg>
+              </span>
             </div>
-            <span class="rounded-full border border-white/30 px-4 py-2 text-sm text-white/70">Suit &amp; Thai: 24% (+3)</span>
-          </header>
-          <div class="grid gap-4 md:grid-cols-2 text-sm text-white/70">
-            <div class="rounded-2xl bg-white/5 p-5 space-y-2">
-              <p class="text-white text-lg font-light">Sentiment</p>
-              <p>Suit &amp; Thai trending 92% positive; key words: "friendly", "comfort", "pineapple curry".</p>
-            </div>
-            <div class="rounded-2xl bg-white/5 p-5 space-y-2">
-              <p class="text-white text-lg font-light">Velocity</p>
-              <p>Mentions up 11% WoW; spike from @seattlespoon and Seattle Met newsletter feature.</p>
+            <div class="mt-6 text-4xl font-light">4.6 ★</div>
+            <div class="mt-auto flex items-center justify-between text-xs text-white/60">
+              <span class="rounded-full bg-white/10 px-3 py-1">30 min wait</span>
+              <span class="text-white/40">+9% buzz</span>
             </div>
           </div>
-          <div class="rounded-2xl bg-white/5 p-5 space-y-3 text-sm text-white/70">
-            <p class="text-xs uppercase tracking-widest text-white/40">Opportunities</p>
-            <ul class="space-y-2">
-              <li>Own "late-night Thai near UW" query with dedicated landing page.</li>
-              <li>Boost TikTok cadence to match Pinto Bistro (3 posts/week).</li>
-              <li>Pitch KING 5 "Evening" for a summer patio segment.</li>
-            </ul>
+
+          <div class="rounded-[28px] border border-white/10 bg-white/5 p-6 backdrop-blur flex flex-col">
+            <div class="flex items-center justify-between text-xs uppercase tracking-[0.35em] text-white/60">
+              <span>Pinto Bistro</span>
+              <span class="inline-flex h-9 w-9 items-center justify-center rounded-2xl bg-white/15 text-white/80">
+                <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                  <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M3 12h18" />
+                </svg>
+              </span>
+            </div>
+            <div class="mt-6 text-4xl font-light">4.4 ★</div>
+            <div class="mt-auto flex items-center justify-between text-xs text-white/60">
+              <span class="rounded-full bg-white/10 px-3 py-1">Paid ads +6%</span>
+              <span class="text-white/40">watch</span>
+            </div>
+          </div>
+
+          <div class="rounded-[28px] border border-white/10 bg-white/5 p-6 backdrop-blur flex flex-col">
+            <div class="flex items-center justify-between text-xs uppercase tracking-[0.35em] text-white/60">
+              <span>Lanna House</span>
+              <span class="inline-flex h-9 w-9 items-center justify-center rounded-2xl bg-white/15 text-white/80">
+                <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                  <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M5 12l5 5L20 7" />
+                </svg>
+              </span>
+            </div>
+            <div class="mt-6 text-4xl font-light">4.7 ★</div>
+            <div class="mt-auto flex items-center justify-between text-xs text-white/60">
+              <span class="rounded-full bg-white/10 px-3 py-1">New patio</span>
+              <span class="text-white/40">opening</span>
+            </div>
+          </div>
+        </section>
+
+        <section class="grid gap-6 lg:grid-cols-[1.2fr,0.8fr]">
+          <div class="rounded-[32px] border border-white/10 bg-white/5 p-8 backdrop-blur space-y-6">
+            <div class="flex items-center justify-between">
+              <h2 class="text-2xl font-light">Share of voice</h2>
+              <span class="text-xs uppercase tracking-[0.4em] text-white/40">30d</span>
+            </div>
+            <div class="grid gap-4 sm:grid-cols-3 text-sm text-white/70">
+              <div class="rounded-3xl bg-gradient-to-br from-blue-500/30 via-blue-500/10 to-white/10 p-5">
+                <p class="text-xs uppercase tracking-[0.35em] text-white/60">Search</p>
+                <p class="mt-5 text-2xl font-light">42%</p>
+              </div>
+              <div class="rounded-3xl bg-gradient-to-br from-emerald-500/30 via-emerald-500/10 to-white/10 p-5">
+                <p class="text-xs uppercase tracking-[0.35em] text-white/60">Social</p>
+                <p class="mt-5 text-2xl font-light">33%</p>
+              </div>
+              <div class="rounded-3xl bg-gradient-to-br from-amber-500/30 via-amber-500/10 to-white/10 p-5">
+                <p class="text-xs uppercase tracking-[0.35em] text-white/60">Press</p>
+                <p class="mt-5 text-2xl font-light">25%</p>
+              </div>
+            </div>
+          </div>
+
+          <aside class="rounded-[32px] border border-white/10 bg-white/5 p-8 backdrop-blur space-y-6">
+            <h2 class="text-2xl font-light">Moves to watch</h2>
+            <div class="space-y-4 text-sm text-white/70">
+              <div class="flex items-center justify-between">
+                <span class="rounded-full bg-white/15 px-3 py-1 text-xs uppercase tracking-[0.35em]">Thai Tom</span>
+                <span class="text-white/60">Late-night menu drop</span>
+              </div>
+              <div class="flex items-center justify-between">
+                <span class="rounded-full bg-white/15 px-3 py-1 text-xs uppercase tracking-[0.35em]">Pinto</span>
+                <span class="text-white/60">SEM bid hike</span>
+              </div>
+              <div class="flex items-center justify-between">
+                <span class="rounded-full bg-white/15 px-3 py-1 text-xs uppercase tracking-[0.35em]">Lanna</span>
+                <span class="text-white/60">Influencer dinners</span>
+              </div>
+            </div>
+          </aside>
+        </section>
+
+        <section class="rounded-[32px] border border-white/10 bg-white/5 p-8 backdrop-blur">
+          <div class="flex flex-wrap items-center justify-between gap-4">
+            <h2 class="text-2xl font-light">Positioning map</h2>
+            <span class="text-xs uppercase tracking-[0.4em] text-white/40">live</span>
+          </div>
+          <div class="mt-8 h-64 rounded-3xl border border-white/15 bg-white/5 relative overflow-hidden">
+            <div class="absolute inset-6 grid grid-cols-3 grid-rows-3 gap-4">
+              <div class="rounded-2xl border border-white/15"></div>
+              <div class="rounded-2xl border border-white/15"></div>
+              <div class="rounded-2xl border border-white/15"></div>
+              <div class="rounded-2xl border border-white/15"></div>
+              <div class="rounded-2xl border border-white/15 bg-gradient-to-br from-fuchsia-500/40 via-fuchsia-500/20 to-white/10 flex items-center justify-center text-sm uppercase tracking-[0.35em]">Suit &amp; Tie</div>
+              <div class="rounded-2xl border border-white/15"></div>
+              <div class="rounded-2xl border border-white/15"></div>
+              <div class="rounded-2xl border border-white/15"></div>
+              <div class="rounded-2xl border border-white/15"></div>
+            </div>
           </div>
         </section>
       </main>

--- a/demo.html
+++ b/demo.html
@@ -55,173 +55,148 @@
               />
             </svg>
           </button>
-          <div class="text-4xl md:text-5xl font-script tracking-wide">genie</div>
+          <div class="text-4xl md:text-5xl font-script tracking-wide italic">genie</div>
         </div>
-        <div class="text-right space-y-2">
-          <p class="uppercase tracking-[0.35em] text-xs text-muted">Suit &amp; Thai Restaurant</p>
-          <p class="text-sm text-white/70">your AI business advisor</p>
+        <div class="text-right">
+          <p class="uppercase tracking-[0.4em] text-xs text-white/60">your AI business advisor</p>
         </div>
       </header>
 
       <main class="flex-1 px-6 md:px-12 py-16">
         <section class="max-w-4xl">
-          <h1 class="text-5xl md:text-6xl font-light mb-6">Hi Bakeree!</h1>
-          <p class="text-lg text-white/60 max-w-xl">
-            Explore how Genie keeps Suit &amp; Thai Restaurant effortlessly on top of Seattle's dining scene.
-          </p>
+          <h1 class="text-5xl md:text-6xl font-light mb-2">Hi Suit &amp; Tie</h1>
+          <p class="text-sm uppercase tracking-[0.5em] text-white/40">tap an app to dive in</p>
         </section>
 
         <section class="mt-16">
           <h2 class="sr-only">Apps</h2>
-          <div class="grid gap-6 sm:grid-cols-2 xl:grid-cols-3">
+          <div class="grid gap-5 grid-cols-2 md:grid-cols-3 xl:grid-cols-4 auto-rows-[200px]">
             <a
               href="marketing.html"
-              class="group relative overflow-hidden rounded-3xl border border-white/10 bg-white/5 p-6 transition hover:border-white/40 hover:bg-white/10"
+              class="group relative flex flex-col justify-between overflow-hidden rounded-[26px] border border-white/10 bg-gradient-to-br from-fuchsia-500/30 via-fuchsia-500/10 to-white/5 p-6 backdrop-blur transition hover:-translate-y-1 hover:border-white/40"
             >
-              <div class="flex items-center justify-between">
-                <span class="text-sm uppercase tracking-widest text-muted">Marketing</span>
-                <span class="inline-flex h-10 w-10 items-center justify-center rounded-full bg-white/10 text-white/80">
+              <div class="flex items-start justify-between">
+                <span class="inline-flex h-11 w-11 items-center justify-center rounded-2xl bg-white/20 text-white/90">
                   <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M12 6v12m6-6H6" />
+                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M12 8c-1.105 0-2 .672-2 1.5S10.895 11 12 11m0-3c1.105 0 2 .672 2 1.5S13.105 12 12 12m0 0c-1.105 0-2 .672-2 1.5S10.895 15 12 15m0-3c1.105 0 2 .672 2 1.5S13.105 15 12 15m0 3v-3m0-6V6" />
                   </svg>
                 </span>
-              </div>
-              <p class="mt-8 text-2xl font-light">Performance storytelling for Seattle foodies.</p>
-              <div class="mt-6 flex items-center text-sm text-white/60">
-                <span>Tap to review Genie insights</span>
-                <svg class="ml-2 h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                <svg class="h-5 w-5 text-white/60 transition group-hover:translate-x-1" fill="none" viewBox="0 0 24 24" stroke="currentColor">
                   <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M9 5l7 7-7 7" />
                 </svg>
               </div>
+              <h3 class="text-2xl font-medium tracking-tight">Marketing</h3>
+              <p class="text-xs uppercase tracking-[0.3em] text-white/70">open</p>
             </a>
 
             <a
               href="growth.html"
-              class="group relative overflow-hidden rounded-3xl border border-white/10 bg-white/5 p-6 transition hover:border-white/40 hover:bg-white/10"
+              class="group relative flex flex-col justify-between overflow-hidden rounded-[26px] border border-white/10 bg-gradient-to-br from-emerald-500/30 via-emerald-500/10 to-white/5 p-6 backdrop-blur transition hover:-translate-y-1 hover:border-white/40"
             >
-              <div class="flex items-center justify-between">
-                <span class="text-sm uppercase tracking-widest text-muted">Growth</span>
-                <span class="inline-flex h-10 w-10 items-center justify-center rounded-full bg-white/10 text-white/80">
+              <div class="flex items-start justify-between">
+                <span class="inline-flex h-11 w-11 items-center justify-center rounded-2xl bg-white/20 text-white/90">
                   <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
                     <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M3 17l6-6 4 4 8-8" />
                   </svg>
                 </span>
-              </div>
-              <p class="mt-8 text-2xl font-light">Model weekly covers and campaign lift.</p>
-              <div class="mt-6 flex items-center text-sm text-white/60">
-                <span>Tap to see pipeline levers</span>
-                <svg class="ml-2 h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                <svg class="h-5 w-5 text-white/60 transition group-hover:translate-x-1" fill="none" viewBox="0 0 24 24" stroke="currentColor">
                   <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M9 5l7 7-7 7" />
                 </svg>
               </div>
+              <h3 class="text-2xl font-medium tracking-tight">Growth</h3>
+              <p class="text-xs uppercase tracking-[0.3em] text-white/70">open</p>
             </a>
 
             <a
               href="competitors.html"
-              class="group relative overflow-hidden rounded-3xl border border-white/10 bg-white/5 p-6 transition hover:border-white/40 hover:bg-white/10"
+              class="group relative flex flex-col justify-between overflow-hidden rounded-[26px] border border-white/10 bg-gradient-to-br from-blue-500/30 via-blue-500/10 to-white/5 p-6 backdrop-blur transition hover:-translate-y-1 hover:border-white/40"
             >
-              <div class="flex items-center justify-between">
-                <span class="text-sm uppercase tracking-widest text-muted">Competitors</span>
-                <span class="inline-flex h-10 w-10 items-center justify-center rounded-full bg-white/10 text-white/80">
+              <div class="flex items-start justify-between">
+                <span class="inline-flex h-11 w-11 items-center justify-center rounded-2xl bg-white/20 text-white/90">
                   <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
                     <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M12 6l8 4-8 4-8-4 8-4z" />
                     <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M4 14l8 4 8-4" />
                   </svg>
                 </span>
-              </div>
-              <p class="mt-8 text-2xl font-light">See how nearby Thai favorites are moving.</p>
-              <div class="mt-6 flex items-center text-sm text-white/60">
-                <span>Tap to compare local buzz</span>
-                <svg class="ml-2 h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                <svg class="h-5 w-5 text-white/60 transition group-hover:translate-x-1" fill="none" viewBox="0 0 24 24" stroke="currentColor">
                   <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M9 5l7 7-7 7" />
                 </svg>
               </div>
+              <h3 class="text-2xl font-medium tracking-tight">Competitors</h3>
+              <p class="text-xs uppercase tracking-[0.3em] text-white/70">open</p>
             </a>
 
             <a
               href="inventory.html"
-              class="group relative overflow-hidden rounded-3xl border border-white/10 bg-white/5 p-6 transition hover:border-white/40 hover:bg-white/10"
+              class="group relative flex flex-col justify-between overflow-hidden rounded-[26px] border border-white/10 bg-gradient-to-br from-orange-500/30 via-orange-500/10 to-white/5 p-6 backdrop-blur transition hover:-translate-y-1 hover:border-white/40"
             >
-              <div class="flex items-center justify-between">
-                <span class="text-sm uppercase tracking-widest text-muted">Inventory</span>
-                <span class="inline-flex h-10 w-10 items-center justify-center rounded-full bg-white/10 text-white/80">
+              <div class="flex items-start justify-between">
+                <span class="inline-flex h-11 w-11 items-center justify-center rounded-2xl bg-white/20 text-white/90">
                   <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
                     <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M3 7h18M3 12h18M3 17h18" />
                   </svg>
                 </span>
+                <svg class="h-5 w-5 text-white/60 transition group-hover:translate-x-1" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                  <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M9 5l7 7-7 7" />
+                </svg>
               </div>
-              <p class="mt-8 text-2xl font-light">Stock intelligence coming soon.</p>
-              <div class="mt-6 text-sm text-white/60">Awaiting POS integration.</div>
+              <h3 class="text-2xl font-medium tracking-tight">Inventory</h3>
+              <p class="text-xs uppercase tracking-[0.3em] text-white/70">open</p>
             </a>
 
             <a
               href="finances.html"
-              class="group relative overflow-hidden rounded-3xl border border-white/10 bg-white/5 p-6 transition hover:border-white/40 hover:bg-white/10"
+              class="group relative flex flex-col justify-between overflow-hidden rounded-[26px] border border-white/10 bg-gradient-to-br from-amber-500/30 via-amber-500/10 to-white/5 p-6 backdrop-blur transition hover:-translate-y-1 hover:border-white/40"
             >
-              <div class="flex items-center justify-between">
-                <span class="text-sm uppercase tracking-widest text-muted">Finances</span>
-                <span class="inline-flex h-10 w-10 items-center justify-center rounded-full bg-white/10 text-white/80">
+              <div class="flex items-start justify-between">
+                <span class="inline-flex h-11 w-11 items-center justify-center rounded-2xl bg-white/20 text-white/90">
                   <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
                     <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M12 8c-1.657 0-3 .895-3 2s1.343 2 3 2 3 .895 3 2-1.343 2-3 2m0-8c1.105 0 2 .672 2 1.5S13.105 11 12 11m0-3c-1.105 0-2-.672-2-1.5S10.895 5 12 5m0 14v-2m0-10V5" />
                   </svg>
                 </span>
+                <svg class="h-5 w-5 text-white/60 transition group-hover:translate-x-1" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                  <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M9 5l7 7-7 7" />
+                </svg>
               </div>
-              <p class="mt-8 text-2xl font-light">Margin tracking coming soon.</p>
-              <div class="mt-6 text-sm text-white/60">Hooking into Square + QuickBooks.</div>
+              <h3 class="text-2xl font-medium tracking-tight">Finances</h3>
+              <p class="text-xs uppercase tracking-[0.3em] text-white/70">open</p>
             </a>
 
             <a
               href="experiments.html"
-              class="group relative overflow-hidden rounded-3xl border border-white/10 bg-white/5 p-6 transition hover:border-white/40 hover:bg-white/10"
+              class="group relative flex flex-col justify-between overflow-hidden rounded-[26px] border border-white/10 bg-gradient-to-br from-indigo-500/30 via-indigo-500/10 to-white/5 p-6 backdrop-blur transition hover:-translate-y-1 hover:border-white/40"
             >
-              <div class="flex items-center justify-between">
-                <span class="text-sm uppercase tracking-widest text-muted">Experiments</span>
-                <span class="inline-flex h-10 w-10 items-center justify-center rounded-full bg-white/10 text-white/80">
+              <div class="flex items-start justify-between">
+                <span class="inline-flex h-11 w-11 items-center justify-center rounded-2xl bg-white/20 text-white/90">
                   <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
                     <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M4.5 3.75h15m-12 0v6.878a2.25 2.25 0 01-.659 1.591l-1.885 1.885a2.25 2.25 0 001.591 3.841h10.866a2.25 2.25 0 001.591-3.841l-1.885-1.885a2.25 2.25 0 01-.659-1.591V3.75" />
                   </svg>
                 </span>
-              </div>
-              <p class="mt-8 text-2xl font-light">Track live tests and outcomes.</p>
-              <div class="mt-6 flex items-center text-sm text-white/60">
-                <span>Tap to view experiment wall</span>
-                <svg class="ml-2 h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                <svg class="h-5 w-5 text-white/60 transition group-hover:translate-x-1" fill="none" viewBox="0 0 24 24" stroke="currentColor">
                   <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M9 5l7 7-7 7" />
                 </svg>
               </div>
+              <h3 class="text-2xl font-medium tracking-tight">Experiments</h3>
+              <p class="text-xs uppercase tracking-[0.3em] text-white/70">open</p>
             </a>
 
             <a
               href="human-advisor.html"
-              class="group relative overflow-hidden rounded-3xl border border-white/10 bg-white/5 p-6 transition hover:border-white/40 hover:bg-white/10"
+              class="group relative flex flex-col justify-between overflow-hidden rounded-[26px] border border-white/10 bg-gradient-to-br from-rose-500/30 via-rose-500/10 to-white/5 p-6 backdrop-blur transition hover:-translate-y-1 hover:border-white/40"
             >
-              <div class="flex items-center justify-between">
-                <span class="text-sm uppercase tracking-widest text-muted">Human Advisor</span>
-                <span class="inline-flex h-10 w-10 items-center justify-center rounded-full bg-white/10 text-white/80">
+              <div class="flex items-start justify-between">
+                <span class="inline-flex h-11 w-11 items-center justify-center rounded-2xl bg-white/20 text-white/90">
                   <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
                     <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M16 7a4 4 0 11-8 0 4 4 0 018 0z" />
-                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M6 21v-2a4 4 0 014-4h4a4 4 0 014 4v2" />
+                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M12 14a7 7 0 00-7 7h14a7 7 0 00-7-7z" />
                   </svg>
                 </span>
+                <svg class="h-5 w-5 text-white/60 transition group-hover:translate-x-1" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                  <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M9 5l7 7-7 7" />
+                </svg>
               </div>
-              <p class="mt-8 text-2xl font-light">Drop into a live strategist session.</p>
-              <div class="mt-6 text-sm text-white/60">Chat, notes, and call in one place.</div>
-            </a>
-
-            <a
-              href="genie-advisor.html"
-              class="group relative overflow-hidden rounded-3xl border border-white/10 bg-white/5 p-6 transition hover:border-white/40 hover:bg-white/10"
-            >
-              <div class="flex items-center justify-between">
-                <span class="text-sm uppercase tracking-widest text-muted">Genie Chat</span>
-                <span class="inline-flex h-10 w-10 items-center justify-center rounded-full bg-white/10 text-white/80">
-                  <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M7.5 8.25h9m-9 3h5.25M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
-                  </svg>
-                </span>
-              </div>
-              <p class="mt-8 text-2xl font-light">Ask anything, anytime.</p>
-              <div class="mt-6 text-sm text-white/60">Tap for the ambient advisor.</div>
+              <h3 class="text-2xl font-medium tracking-tight">Human Advisor</h3>
+              <p class="text-xs uppercase tracking-[0.3em] text-white/70">open</p>
             </a>
           </div>
         </section>

--- a/experiments.html
+++ b/experiments.html
@@ -14,9 +14,6 @@
             },
             colors: {
               night: '#050505',
-              surface: 'rgba(255,255,255,0.04)',
-              success: '#4ade80',
-              pending: '#facc15',
             },
           },
         },
@@ -27,10 +24,15 @@
       rel="stylesheet"
       href="https://fonts.googleapis.com/css2?family=Great+Vibes&family=Inter:wght@300;400;500;600;700&display=swap"
     />
+    <style>
+      body {
+        background: #030303;
+      }
+    </style>
   </head>
   <body class="min-h-screen bg-night text-white font-sans">
-    <div class="min-h-screen px-6 md:px-12 pb-16">
-      <header class="py-8 flex items-start justify-between">
+    <div class="min-h-screen flex flex-col px-6 md:px-12 py-10">
+      <header class="flex items-start justify-between">
         <div class="space-y-4">
           <button
             onclick="window.location.href='demo.html'"
@@ -41,152 +43,144 @@
               <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M15 19l-7-7 7-7" />
             </svg>
           </button>
-          <div class="text-4xl font-script tracking-wide">genie</div>
+          <div class="text-4xl font-script tracking-wide italic">genie</div>
         </div>
         <div class="text-right">
-          <p class="uppercase tracking-[0.35em] text-xs text-white/50">Suit &amp; Thai Restaurant</p>
-          <p class="text-sm text-white/60">Experiment wall</p>
+          <p class="uppercase tracking-[0.4em] text-xs text-white/60">your AI business advisor</p>
         </div>
       </header>
 
-      <main class="space-y-12">
+      <main class="flex-1 py-10 flex flex-col gap-12">
         <section class="max-w-4xl">
-          <p class="text-sm uppercase tracking-[0.4em] text-white/40">Overview</p>
-          <h1 class="mt-4 text-5xl font-light">Measure what Genie nudges</h1>
-          <p class="mt-6 text-lg text-white/60 leading-relaxed">
-            Every recommendation becomes an experiment with a clear hypothesis, metric, and result readout. Once an experiment graduates, its
-            learnings feed directly into Genie playbooks for Suit &amp; Thai.
-          </p>
+          <h1 class="text-5xl md:text-6xl font-light">Experiments</h1>
+          <p class="mt-3 text-sm uppercase tracking-[0.5em] text-white/40">playground</p>
         </section>
 
-        <section class="flex flex-wrap items-center justify-between gap-4">
-          <div class="flex items-center gap-3 text-sm text-white/60">
-            <span class="inline-flex h-3 w-3 rounded-full bg-success"></span>
-            <span>Winning</span>
-            <span class="inline-flex h-3 w-3 rounded-full bg-pending ml-4"></span>
-            <span>Running</span>
+        <section class="rounded-[32px] border border-white/10 bg-white/5 p-8 backdrop-blur">
+          <div class="flex flex-wrap items-center justify-between gap-4">
+            <h2 class="text-2xl font-light">Wall</h2>
+            <button
+              id="addExperiment"
+              class="inline-flex items-center gap-2 rounded-full border border-white/30 px-4 py-2 text-sm font-medium text-white hover:border-white/60 transition"
+              type="button"
+            >
+              <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M12 6v12m6-6H6" />
+              </svg>
+              Add experiment
+            </button>
           </div>
-          <button
-            type="button"
-            class="inline-flex items-center gap-2 rounded-full border border-white/40 px-5 py-2 text-sm font-medium text-white hover:border-white transition"
-          >
-            <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M12 6v12m6-6H6" />
-            </svg>
-            Add experiment
-          </button>
-        </section>
-
-        <section class="space-y-6">
-          <article id="uw-finals" class="rounded-3xl border border-white/10 bg-surface p-6">
-            <div class="flex flex-wrap items-center justify-between gap-4">
-              <div>
-                <p class="text-xs uppercase tracking-widest text-white/40">Marketing · Running</p>
-                <h2 class="text-3xl font-light">UW Finals Comfort Tour</h2>
-              </div>
-              <span class="inline-flex items-center gap-2 rounded-full border border-pending/40 bg-pending/10 px-4 py-1 text-xs font-medium text-pending-200">
-                <span class="h-2 w-2 rounded-full bg-pending"></span>
-                In flight
-              </span>
-            </div>
-            <div class="mt-6 grid gap-6 lg:grid-cols-[1.1fr,0.9fr]">
-              <div class="space-y-4 text-sm text-white/70">
-                <p><span class="text-white">Hypothesis:</span> Finals-week storytelling across TikTok and Instagram will lift late-night delivery orders by 14%.</p>
-                <p><span class="text-white">Play:</span> Two chef-led study snack videos, UW student testimonials, DoorDash late-night bundle with Thai iced tea.</p>
-                <p><span class="text-white">Owner:</span> Mila Chen · Launch date: May 20</p>
-              </div>
-              <div class="grid gap-4 sm:grid-cols-2">
-                <div class="rounded-2xl bg-white/5 p-4">
-                  <h3 class="text-xs uppercase tracking-widest text-white/40">Metric</h3>
-                  <p class="mt-2 text-lg font-light text-white">Late-night delivery orders</p>
-                  <p class="text-sm text-white/60">Goal: +14% vs prior 2-week baseline</p>
-                  <p class="mt-2 text-2xl font-light text-pending">+9.6%</p>
-                </div>
-                <div class="rounded-2xl bg-white/5 p-4">
-                  <h3 class="text-xs uppercase tracking-widest text-white/40">Results</h3>
-                  <ul class="mt-2 space-y-1 text-sm text-white/70">
-                    <li>Story completion rate 68%</li>
-                    <li>DoorDash bundle attach 1.7×</li>
-                    <li>UW subreddit mentions +5</li>
-                  </ul>
-                </div>
-              </div>
-            </div>
-          </article>
-
-          <article id="pad-thai-passport" class="rounded-3xl border border-white/10 bg-surface p-6">
-            <div class="flex flex-wrap items-center justify-between gap-4">
-              <div>
-                <p class="text-xs uppercase tracking-widest text-white/40">Loyalty · Winning</p>
-                <h2 class="text-3xl font-light">Pad Thai Passport</h2>
-              </div>
-              <span class="inline-flex items-center gap-2 rounded-full border border-success/40 bg-success/10 px-4 py-1 text-xs font-medium text-success-200">
-                <span class="h-2 w-2 rounded-full bg-success"></span>
-                Adopted
-              </span>
-            </div>
-            <div class="mt-6 grid gap-6 lg:grid-cols-[1.1fr,0.9fr]">
-              <div class="space-y-4 text-sm text-white/70">
-                <p><span class="text-white">Hypothesis:</span> A five-stamp dine-in passport will increase repeat visits and catalyze more Google reviews.</p>
-                <p><span class="text-white">Play:</span> Table talkers, QR sign-up, dessert reward, follow-up email after second visit.</p>
-                <p><span class="text-white">Owner:</span> Front-of-house team · Launch date: April 10</p>
-              </div>
-              <div class="grid gap-4 sm:grid-cols-2">
-                <div class="rounded-2xl bg-white/5 p-4">
-                  <h3 class="text-xs uppercase tracking-widest text-white/40">Metric</h3>
-                  <p class="mt-2 text-lg font-light text-white">Repeat visit rate</p>
-                  <p class="text-sm text-white/60">Goal: +9%</p>
-                  <p class="mt-2 text-2xl font-light text-success">+11.4%</p>
-                </div>
-                <div class="rounded-2xl bg-white/5 p-4">
-                  <h3 class="text-xs uppercase tracking-widest text-white/40">Results</h3>
-                  <ul class="mt-2 space-y-1 text-sm text-white/70">
-                    <li>321 passports issued</li>
-                    <li>Dessert COGS up $92 · margin offset by +$1.8k revenue</li>
-                    <li>Google reviews mentioning "passport": +17</li>
-                  </ul>
-                </div>
-              </div>
-            </div>
-          </article>
-
-          <article id="night-market" class="rounded-3xl border border-white/10 bg-surface p-6">
-            <div class="flex flex-wrap items-center justify-between gap-4">
-              <div>
-                <p class="text-xs uppercase tracking-widest text-white/40">PR · Preparing</p>
-                <h2 class="text-3xl font-light">Neighborhood Night Market</h2>
-              </div>
-              <span class="inline-flex items-center gap-2 rounded-full border border-white/30 bg-white/10 px-4 py-1 text-xs font-medium text-white/70">
-                <span class="h-2 w-2 rounded-full bg-white/50"></span>
-                Drafting
-              </span>
-            </div>
-            <div class="mt-6 grid gap-6 lg:grid-cols-[1.1fr,0.9fr]">
-              <div class="space-y-4 text-sm text-white/70">
-                <p><span class="text-white">Hypothesis:</span> A collaborative night market will generate 540 high-intent impressions and 200 emails.</p>
-                <p><span class="text-white">Play:</span> Partner with four U-District vendors, co-create tasting passports, secure Eater Seattle preview.</p>
-                <p><span class="text-white">Owner:</span> Genie Ops Pod · Launch target: June 15</p>
-              </div>
-              <div class="grid gap-4 sm:grid-cols-2">
-                <div class="rounded-2xl bg-white/5 p-4">
-                  <h3 class="text-xs uppercase tracking-widest text-white/40">Metric</h3>
-                  <p class="mt-2 text-lg font-light text-white">Emails captured</p>
-                  <p class="text-sm text-white/60">Goal: 200</p>
-                  <p class="mt-2 text-2xl font-light text-white/50">Planning</p>
-                </div>
-                <div class="rounded-2xl bg-white/5 p-4">
-                  <h3 class="text-xs uppercase tracking-widest text-white/40">Results</h3>
-                  <ul class="mt-2 space-y-1 text-sm text-white/70">
-                    <li>Vendor commitments: 3/4 signed</li>
-                    <li>Press outreach: draft ready</li>
-                    <li>Budget hold: $600</li>
-                  </ul>
-                </div>
-              </div>
-            </div>
-          </article>
+          <div id="experiment-board" class="mt-8 grid gap-6 md:grid-cols-2"></div>
         </section>
       </main>
     </div>
+
+    <div
+      id="experiment-modal"
+      class="fixed inset-0 z-50 hidden items-center justify-center bg-black/70 px-6"
+      role="dialog"
+      aria-modal="true"
+    >
+      <div class="w-full max-w-sm rounded-3xl border border-white/10 bg-white/10 p-6 backdrop-blur">
+        <h2 class="text-xl font-light">Create experiment</h2>
+        <label class="mt-4 block text-sm text-white/70">Title</label>
+        <input
+          id="experiment-title-input"
+          type="text"
+          class="mt-2 w-full rounded-2xl border border-white/20 bg-black/40 px-4 py-3 text-sm text-white focus:outline-none focus:border-white/60"
+          placeholder="Give it a name"
+        />
+        <div class="mt-6 flex items-center justify-end gap-3 text-sm">
+          <button id="cancel-experiment" type="button" class="rounded-full border border-white/30 px-4 py-2 text-white hover:border-white/60 transition">
+            Cancel
+          </button>
+          <button id="create-experiment" type="button" class="rounded-full bg-white px-4 py-2 text-black hover:bg-white/80 transition">
+            Create
+          </button>
+        </div>
+      </div>
+    </div>
+
+    <template id="experiment-template">
+      <div class="experiment-card rounded-[32px] border border-white/10 bg-white/5 p-6 backdrop-blur flex flex-col items-center gap-6">
+        <div
+          class="w-full rounded-3xl bg-gradient-to-r from-indigo-500/30 via-indigo-500/10 to-white/10 px-4 py-3 text-center text-lg font-light focus:outline-none"
+          contenteditable="true"
+        ></div>
+        <div class="flex w-full items-start justify-between gap-6">
+          <div class="flex-1 flex flex-col items-center gap-3">
+            <svg class="h-12 w-12 text-white/40" viewBox="0 0 48 48" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+              <path d="M24 4v28" />
+              <path d="M24 32l-6-6" />
+              <path d="M24 32l6-6" />
+            </svg>
+            <div
+              class="w-full rounded-3xl border border-white/15 bg-white/5 px-4 py-3 text-sm text-white/80"
+              contenteditable="true"
+              data-placeholder="Results"
+            >Results...</div>
+          </div>
+          <div class="flex-1 flex flex-col items-center gap-3">
+            <svg class="h-12 w-12 text-white/40" viewBox="0 0 48 48" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+              <path d="M24 4v28" />
+              <path d="M24 32l-6-6" />
+              <path d="M24 32l6-6" />
+            </svg>
+            <div
+              class="w-full rounded-3xl border border-white/15 bg-white/5 px-4 py-3 text-sm text-white/80"
+              contenteditable="true"
+              data-placeholder="Evidence"
+            >Evidence...</div>
+          </div>
+        </div>
+      </div>
+    </template>
+
+    <script>
+      const board = document.getElementById('experiment-board');
+      const modal = document.getElementById('experiment-modal');
+      const titleInput = document.getElementById('experiment-title-input');
+      const addButton = document.getElementById('addExperiment');
+      const createButton = document.getElementById('create-experiment');
+      const cancelButton = document.getElementById('cancel-experiment');
+      const template = document.getElementById('experiment-template');
+
+      function openModal() {
+        modal.classList.remove('hidden');
+        modal.classList.add('flex');
+        titleInput.value = '';
+        setTimeout(() => titleInput.focus(), 50);
+      }
+
+      function closeModal() {
+        modal.classList.add('hidden');
+        modal.classList.remove('flex');
+      }
+
+      function createExperimentCard(title) {
+        const clone = template.content.firstElementChild.cloneNode(true);
+        const titleBox = clone.querySelector('[contenteditable="true"]');
+        titleBox.textContent = title;
+        board.appendChild(clone);
+      }
+
+      addButton.addEventListener('click', openModal);
+      cancelButton.addEventListener('click', closeModal);
+
+      createButton.addEventListener('click', () => {
+        const title = titleInput.value.trim() || 'Untitled experiment';
+        createExperimentCard(title);
+        closeModal();
+      });
+
+      modal.addEventListener('click', (event) => {
+        if (event.target === modal) {
+          closeModal();
+        }
+      });
+
+      // Seed a couple of cards for context
+      ['UW finals comfort tour', 'Pad thai passport'].forEach(createExperimentCard);
+    </script>
   </body>
 </html>

--- a/finances.html
+++ b/finances.html
@@ -14,8 +14,6 @@
             },
             colors: {
               night: '#050505',
-              surface: 'rgba(255,255,255,0.04)',
-              accent: '#f472b6',
             },
           },
         },
@@ -26,10 +24,15 @@
       rel="stylesheet"
       href="https://fonts.googleapis.com/css2?family=Great+Vibes&family=Inter:wght@300;400;500;600;700&display=swap"
     />
+    <style>
+      body {
+        background: #030303;
+      }
+    </style>
   </head>
   <body class="min-h-screen bg-night text-white font-sans">
-    <div class="min-h-screen px-6 md:px-12 pb-16 flex flex-col">
-      <header class="py-8 flex items-start justify-between">
+    <div class="min-h-screen flex flex-col px-6 md:px-12 py-10">
+      <header class="flex items-start justify-between">
         <div class="space-y-4">
           <button
             onclick="window.location.href='demo.html'"
@@ -40,39 +43,143 @@
               <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M15 19l-7-7 7-7" />
             </svg>
           </button>
-          <div class="text-4xl font-script tracking-wide">genie</div>
+          <div class="text-4xl font-script tracking-wide italic">genie</div>
         </div>
         <div class="text-right">
-          <p class="uppercase tracking-[0.35em] text-xs text-white/50">Suit &amp; Thai Restaurant</p>
-          <p class="text-sm text-white/60">Finance cockpit</p>
+          <p class="uppercase tracking-[0.4em] text-xs text-white/60">your AI business advisor</p>
         </div>
       </header>
 
-      <main class="flex-1 flex items-center justify-center">
-        <div class="max-w-2xl text-center space-y-6">
-          <div class="inline-flex items-center rounded-full border border-white/20 px-4 py-2 text-xs uppercase tracking-widest text-white/50">
-            Secure data room coming
+      <main class="flex-1 py-10 flex flex-col gap-12">
+        <section class="max-w-4xl">
+          <h1 class="text-5xl md:text-6xl font-light">Finances</h1>
+          <p class="mt-3 text-sm uppercase tracking-[0.5em] text-white/40">snapshot</p>
+        </section>
+
+        <section class="grid gap-6 md:grid-cols-3">
+          <div class="rounded-[28px] border border-white/10 bg-white/5 p-6 backdrop-blur flex flex-col">
+            <div class="flex items-center justify-between text-xs uppercase tracking-[0.35em] text-white/60">
+              <span>Revenue</span>
+              <span class="inline-flex h-9 w-9 items-center justify-center rounded-2xl bg-white/15 text-white/80">
+                <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                  <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M11 3v18m6-10l-6-8-6 8" />
+                </svg>
+              </span>
+            </div>
+            <div class="mt-6 text-4xl font-light">$82.4k</div>
+            <div class="mt-auto flex items-end gap-1 h-20">
+              <div class="flex-1 rounded-full bg-white/15 h-4"></div>
+              <div class="flex-1 rounded-full bg-white/15 h-8"></div>
+              <div class="flex-1 rounded-full bg-white/15 h-12"></div>
+              <div class="flex-1 rounded-full bg-white/40 h-16"></div>
+            </div>
           </div>
-          <h1 class="text-5xl font-light">Financial telemetry loading</h1>
-          <p class="text-lg text-white/60 leading-relaxed">
-            Genie will plug into Square, QuickBooks, and payroll to map revenue, labor, and COGS in one place. Expect dynamic margin coaching,
-            cash runway alerts, and menu engineering heatmaps once the APIs are unlocked.
-          </p>
-          <div class="rounded-3xl border border-white/10 bg-surface p-6 text-left space-y-4">
-            <h2 class="text-xl font-light text-white">Launch roadmap</h2>
-            <ul class="space-y-2 text-sm text-white/70">
-              <li>Daily P&amp;L rollups with variance explanations</li>
-              <li>Labor-to-sales guardrails with push notifications</li>
-              <li>Menu mix profitability suggestions powered by Genie</li>
-            </ul>
+
+          <div class="rounded-[28px] border border-white/10 bg-white/5 p-6 backdrop-blur flex flex-col">
+            <div class="flex items-center justify-between text-xs uppercase tracking-[0.35em] text-white/60">
+              <span>Margin</span>
+              <span class="inline-flex h-9 w-9 items-center justify-center rounded-2xl bg-white/15 text-white/80">
+                <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                  <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M12 8c-1.657 0-3 .895-3 2s1.343 2 3 2 3 .895 3 2-1.343 2-3 2m0-8c1.105 0 2 .672 2 1.5S13.105 11 12 11m0-3c-1.105 0-2-.672-2-1.5S10.895 5 12 5m0 14v-2m0-10V5" />
+                </svg>
+              </span>
+            </div>
+            <div class="mt-6 text-4xl font-light">34%</div>
+            <div class="mt-auto grid grid-cols-2 gap-2 text-xs text-white/70">
+              <div class="rounded-2xl bg-white/10 px-3 py-2 text-center">Food 28%</div>
+              <div class="rounded-2xl bg-white/10 px-3 py-2 text-center">Labor 32%</div>
+              <div class="rounded-2xl bg-white/10 px-3 py-2 text-center">Ops 18%</div>
+              <div class="rounded-2xl bg-white/10 px-3 py-2 text-center">Marketing 10%</div>
+            </div>
           </div>
-          <a
-            href="demo.html"
-            class="inline-flex items-center justify-center rounded-full border border-white/40 px-6 py-3 text-sm font-medium text-white hover:border-white transition"
-          >
-            Back to home
-          </a>
-        </div>
+
+          <div class="rounded-[28px] border border-white/10 bg-white/5 p-6 backdrop-blur flex flex-col">
+            <div class="flex items-center justify-between text-xs uppercase tracking-[0.35em] text-white/60">
+              <span>Cash</span>
+              <span class="inline-flex h-9 w-9 items-center justify-center rounded-2xl bg-white/15 text-white/80">
+                <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                  <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M12 6v12m6-6H6" />
+                </svg>
+              </span>
+            </div>
+            <div class="mt-6 text-4xl font-light">$46.2k</div>
+            <div class="mt-auto space-y-2 text-xs text-white/60">
+              <div class="rounded-2xl bg-white/10 px-3 py-2">Payroll ready</div>
+              <div class="rounded-2xl bg-white/10 px-3 py-2">Night market fund</div>
+              <div class="rounded-2xl bg-white/10 px-3 py-2">Cushion 6 weeks</div>
+            </div>
+          </div>
+        </section>
+
+        <section class="grid gap-6 lg:grid-cols-[1.2fr,0.8fr]">
+          <div class="rounded-[32px] border border-white/10 bg-white/5 p-8 backdrop-blur space-y-6">
+            <div class="flex items-center justify-between">
+              <h2 class="text-2xl font-light">Forecast lanes</h2>
+              <span class="text-xs uppercase tracking-[0.4em] text-white/40">next 8w</span>
+            </div>
+            <div class="grid gap-4 sm:grid-cols-2 text-sm text-white/70">
+              <div class="rounded-3xl bg-gradient-to-br from-amber-500/30 via-amber-500/10 to-white/10 p-6">
+                <p class="text-xs uppercase tracking-[0.35em] text-white/60">Base</p>
+                <p class="mt-6 text-2xl font-light">$78k</p>
+              </div>
+              <div class="rounded-3xl bg-gradient-to-br from-emerald-500/30 via-emerald-500/10 to-white/10 p-6">
+                <p class="text-xs uppercase tracking-[0.35em] text-white/60">Stretch</p>
+                <p class="mt-6 text-2xl font-light">$92k</p>
+              </div>
+              <div class="rounded-3xl bg-gradient-to-br from-rose-500/30 via-rose-500/10 to-white/10 p-6">
+                <p class="text-xs uppercase tracking-[0.35em] text-white/60">Downside</p>
+                <p class="mt-6 text-2xl font-light">$68k</p>
+              </div>
+              <div class="rounded-3xl bg-gradient-to-br from-blue-500/30 via-blue-500/10 to-white/10 p-6">
+                <p class="text-xs uppercase tracking-[0.35em] text-white/60">Events</p>
+                <p class="mt-6 text-2xl font-light">$12k add</p>
+              </div>
+            </div>
+          </div>
+
+          <aside class="rounded-[32px] border border-white/10 bg-white/5 p-8 backdrop-blur space-y-6">
+            <h2 class="text-2xl font-light">Upcoming notes</h2>
+            <div class="space-y-4 text-sm text-white/70">
+              <div class="flex items-center justify-between">
+                <span class="rounded-full bg-white/15 px-3 py-1 text-xs uppercase tracking-[0.35em]">today</span>
+                <span class="text-white/60">Square sync</span>
+              </div>
+              <div class="flex items-center justify-between">
+                <span class="rounded-full bg-white/15 px-3 py-1 text-xs uppercase tracking-[0.35em]">+3d</span>
+                <span class="text-white/60">Payroll draft</span>
+              </div>
+              <div class="flex items-center justify-between">
+                <span class="rounded-full bg-white/15 px-3 py-1 text-xs uppercase tracking-[0.35em]">+7d</span>
+                <span class="text-white/60">Catering invoicing</span>
+              </div>
+            </div>
+          </aside>
+        </section>
+
+        <section class="rounded-[32px] border border-white/10 bg-white/5 p-8 backdrop-blur">
+          <div class="flex flex-wrap items-center justify-between gap-4">
+            <h2 class="text-2xl font-light">Runway</h2>
+            <span class="text-xs uppercase tracking-[0.4em] text-white/40">monitored</span>
+          </div>
+          <div class="mt-8 grid gap-4 md:grid-cols-4 text-sm text-white/70">
+            <div class="rounded-3xl bg-white/10 p-5 text-center">
+              <p class="text-xs uppercase tracking-[0.35em] text-white/50">Rent</p>
+              <p class="mt-5 text-2xl font-light">paid</p>
+            </div>
+            <div class="rounded-3xl bg-white/10 p-5 text-center">
+              <p class="text-xs uppercase tracking-[0.35em] text-white/50">Vendors</p>
+              <p class="mt-5 text-2xl font-light">on time</p>
+            </div>
+            <div class="rounded-3xl bg-white/10 p-5 text-center">
+              <p class="text-xs uppercase tracking-[0.35em] text-white/50">Marketing</p>
+              <p class="mt-5 text-2xl font-light">budget ok</p>
+            </div>
+            <div class="rounded-3xl bg-white/10 p-5 text-center">
+              <p class="text-xs uppercase tracking-[0.35em] text-white/50">Capex</p>
+              <p class="mt-5 text-2xl font-light">paused</p>
+            </div>
+          </div>
+        </section>
       </main>
     </div>
   </body>

--- a/growth.html
+++ b/growth.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Genie | Growth Dashboard</title>
+    <title>Genie | Growth</title>
     <script>
       tailwind.config = {
         theme: {
@@ -14,9 +14,6 @@
             },
             colors: {
               night: '#050505',
-              surface: 'rgba(255,255,255,0.04)',
-              lime: '#bef264',
-              amber: '#fbbf24',
             },
           },
         },
@@ -27,10 +24,15 @@
       rel="stylesheet"
       href="https://fonts.googleapis.com/css2?family=Great+Vibes&family=Inter:wght@300;400;500;600;700&display=swap"
     />
+    <style>
+      body {
+        background: #030303;
+      }
+    </style>
   </head>
   <body class="min-h-screen bg-night text-white font-sans">
-    <div class="min-h-screen px-6 md:px-12 pb-16">
-      <header class="py-8 flex items-start justify-between">
+    <div class="min-h-screen flex flex-col px-6 md:px-12 py-10">
+      <header class="flex items-start justify-between">
         <div class="space-y-4">
           <button
             onclick="window.location.href='demo.html'"
@@ -41,157 +43,161 @@
               <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M15 19l-7-7 7-7" />
             </svg>
           </button>
-          <div class="text-4xl font-script tracking-wide">genie</div>
+          <div class="text-4xl font-script tracking-wide italic">genie</div>
         </div>
         <div class="text-right">
-          <p class="uppercase tracking-[0.35em] text-xs text-white/50">Suit &amp; Thai Restaurant</p>
-          <p class="text-sm text-white/60">Growth &amp; pipeline</p>
+          <p class="uppercase tracking-[0.4em] text-xs text-white/60">your AI business advisor</p>
         </div>
       </header>
 
-      <main class="space-y-14">
-        <section class="max-w-5xl">
-          <p class="text-sm uppercase tracking-[0.4em] text-white/40">Growth Narrative</p>
-          <h1 class="mt-4 text-5xl font-light">Keeping the dining room and delivery lanes humming</h1>
-          <p class="mt-6 text-lg text-white/60 max-w-3xl leading-relaxed">
-            Genie stitches together reservations, foot traffic, delivery demand, and community events around Golden Singha Thai. The view below
-            looks at how Suit &amp; Thai is pacing toward its 22% YoY revenue growth target for summer 2024.
-          </p>
+      <main class="flex-1 py-10 flex flex-col gap-12">
+        <section class="max-w-4xl">
+          <h1 class="text-5xl md:text-6xl font-light">Growth</h1>
+          <p class="mt-3 text-sm uppercase tracking-[0.5em] text-white/40">momentum</p>
         </section>
 
-        <section class="grid gap-6 lg:grid-cols-[1.1fr,0.9fr]">
-          <article class="rounded-3xl border border-white/10 bg-surface p-8 space-y-8">
-            <header class="flex items-center justify-between">
-              <div>
-                <h2 class="text-3xl font-light">Pipeline Watch</h2>
-                <p class="text-sm text-white/50">Weekly covers forecast vs target</p>
-              </div>
-              <span class="rounded-full border border-lime/40 text-lime px-3 py-1 text-xs uppercase tracking-widest">+6.4% ahead</span>
-            </header>
-            <div class="grid gap-5 md:grid-cols-2 text-sm text-white/70">
-              <div class="rounded-2xl bg-white/5 p-5 space-y-3">
-                <h3 class="text-white text-lg font-light">Dining Room</h3>
-                <p>Reservations pacing <span class="text-white">186</span> covers (goal 172). Spike driven by UW graduation weekend packages.</p>
-                <p class="text-white/60">Waitlist conversion 32% via Resy text nudges.</p>
-              </div>
-              <div class="rounded-2xl bg-white/5 p-5 space-y-3">
-                <h3 class="text-white text-lg font-light">Delivery</h3>
-                <p>DoorDash + Uber Eats projecting <span class="text-white">$14.8k</span> net sales this month, +11% MoM.</p>
-                <p class="text-white/60">Late-night bundle drives 2.3x baskets after 9pm.</p>
-              </div>
-              <div class="rounded-2xl bg-white/5 p-5 space-y-3">
-                <h3 class="text-white text-lg font-light">Catering</h3>
-                <p>Corporate leads in pipeline: <span class="text-white">7</span> (target 5). Microsoft SLU requests Songkran station for June.</p>
-                <p class="text-white/60">Avg quote $1.9k; close rate 43%.</p>
-              </div>
-              <div class="rounded-2xl bg-white/5 p-5 space-y-3">
-                <h3 class="text-white text-lg font-light">Events</h3>
-                <p>Community events locked: Night Market pop-up, U-District Art Walk tasting bar, UW Alumni mixer.</p>
-                <p class="text-white/60">Expect 540 incremental impressions across partner channels.</p>
-              </div>
+        <section class="grid gap-6 md:grid-cols-3">
+          <div class="rounded-[28px] border border-white/10 bg-white/5 p-6 backdrop-blur flex flex-col">
+            <div class="flex items-center justify-between text-xs uppercase tracking-[0.35em] text-white/60">
+              <span>Dining</span>
+              <span class="inline-flex h-9 w-9 items-center justify-center rounded-2xl bg-white/15 text-white/80">
+                <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                  <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M3 17l6-6 4 4 8-8" />
+                </svg>
+              </span>
             </div>
-          </article>
+            <div class="mt-6 text-4xl font-light">186 covers</div>
+            <div class="mt-auto flex items-end gap-1 h-20">
+              <div class="flex-1 rounded-full bg-white/15 h-4"></div>
+              <div class="flex-1 rounded-full bg-white/15 h-8"></div>
+              <div class="flex-1 rounded-full bg-white/15 h-12"></div>
+              <div class="flex-1 rounded-full bg-white/40 h-16"></div>
+            </div>
+          </div>
 
-          <aside class="rounded-3xl border border-white/10 bg-surface p-8 space-y-6">
-            <h2 class="text-2xl font-light">Demand Map</h2>
-            <div class="space-y-4 text-sm text-white/70">
-              <div class="rounded-2xl bg-white/5 p-4">
-                <p class="text-xs uppercase tracking-widest text-white/40">Hotspot</p>
-                <p class="mt-2 text-white">University Way NE</p>
-                <p class="mt-1 text-white/60">Foot traffic +12% vs last month thanks to cherry blossom tourism.</p>
-              </div>
-              <div class="rounded-2xl bg-white/5 p-4">
-                <p class="text-xs uppercase tracking-widest text-white/40">Emerging</p>
-                <p class="mt-2 text-white">South Lake Union lunch</p>
-                <p class="mt-1 text-white/60">Office returns fueling catering demand; focus on express bento sets.</p>
-              </div>
-              <div class="rounded-2xl bg-white/5 p-4">
-                <p class="text-xs uppercase tracking-widest text-white/40">Watch</p>
-                <p class="mt-2 text-white">Capitol Hill late-night</p>
-                <p class="mt-1 text-white/60">Competitors increasing promo spend Fridays; monitor with marketing.</p>
-              </div>
+          <div class="rounded-[28px] border border-white/10 bg-white/5 p-6 backdrop-blur flex flex-col">
+            <div class="flex items-center justify-between text-xs uppercase tracking-[0.35em] text-white/60">
+              <span>Delivery</span>
+              <span class="inline-flex h-9 w-9 items-center justify-center rounded-2xl bg-white/15 text-white/80">
+                <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                  <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M4 6h16m-7 4h7m-7 4h7m-7 4h7" />
+                </svg>
+              </span>
             </div>
-          </aside>
-        </section>
+            <div class="mt-6 text-4xl font-light">$14.8k</div>
+            <div class="mt-auto grid grid-cols-3 gap-3 text-xs text-white/70">
+              <div class="rounded-2xl bg-white/10 px-3 py-2 text-center">Dinner</div>
+              <div class="rounded-2xl bg-white/10 px-3 py-2 text-center">Late</div>
+              <div class="rounded-2xl bg-white/10 px-3 py-2 text-center">Bundles</div>
+            </div>
+          </div>
 
-        <section class="rounded-3xl border border-white/10 bg-surface p-8 space-y-8">
-          <header class="flex flex-wrap items-center justify-between gap-4">
-            <div>
-              <h2 class="text-3xl font-light">Move Board</h2>
-              <p class="text-sm text-white/50">Coordinated plays with Marketing, Experiments, and Operations</p>
+          <div class="rounded-[28px] border border-white/10 bg-white/5 p-6 backdrop-blur flex flex-col">
+            <div class="flex items-center justify-between text-xs uppercase tracking-[0.35em] text-white/60">
+              <span>Pipeline</span>
+              <span class="inline-flex h-9 w-9 items-center justify-center rounded-2xl bg-white/15 text-white/80">
+                <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                  <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M4 12h16m-8-8v16" />
+                </svg>
+              </span>
             </div>
-            <a
-              href="marketing.html#strategy"
-              class="rounded-full border border-white/40 px-4 py-2 text-sm font-medium text-white hover:border-white transition"
-            >
-              View marketing plan
-            </a>
-          </header>
-          <div class="grid gap-6 lg:grid-cols-3 text-sm text-white/70">
-            <div class="rounded-2xl bg-white/5 p-6 space-y-3">
-              <p class="text-xs uppercase tracking-widest text-white/40">This Week</p>
-              <h3 class="text-white text-xl font-light">Chef's Counter Livestream</h3>
-              <p>Coordinate with @seattlespoon live tasting on Thursday. Goal: 250 concurrent viewers; offer QR for 10% dine-in.</p>
-              <p class="text-white/60">Owner: Mila · Status: Locked</p>
-            </div>
-            <div class="rounded-2xl bg-white/5 p-6 space-y-3">
-              <p class="text-xs uppercase tracking-widest text-white/40">Next Week</p>
-              <h3 class="text-white text-xl font-light">UW Finals Comfort Tour</h3>
-              <p>Marketing pushing finals messaging; operations prepping family-size pad thai kits. Track conversion in Experiments.</p>
-              <p class="text-white/60">Owner: Genie · Status: Building</p>
-            </div>
-            <div class="rounded-2xl bg-white/5 p-6 space-y-3">
-              <p class="text-xs uppercase tracking-widest text-white/40">Later</p>
-              <h3 class="text-white text-xl font-light">Night Market Pop-up</h3>
-              <p>Secure permits and vendor alignments by May 30. Finance to model break-even at 320 tastings sold.</p>
-              <p class="text-white/60">Owner: Ops · Status: Planning</p>
+            <div class="mt-6 text-4xl font-light">7 leads</div>
+            <div class="mt-auto space-y-2 text-xs text-white/60">
+              <div class="flex items-center justify-between">
+                <span class="rounded-full bg-white/10 px-3 py-1">Catering</span>
+                <span class="text-white/40">43% win</span>
+              </div>
+              <div class="flex items-center justify-between">
+                <span class="rounded-full bg-white/10 px-3 py-1">Events</span>
+                <span class="text-white/40">3 booked</span>
+              </div>
             </div>
           </div>
         </section>
 
-        <section class="grid gap-6 lg:grid-cols-[1.2fr,0.8fr]">
-          <article class="rounded-3xl border border-white/10 bg-surface p-8 space-y-6">
+        <section class="grid gap-6 lg:grid-cols-[1.1fr,0.9fr]">
+          <div class="rounded-[32px] border border-white/10 bg-white/5 p-8 backdrop-blur space-y-6">
             <div class="flex items-center justify-between">
-              <h2 class="text-2xl font-light">Growth Signals</h2>
-              <span class="text-xs uppercase tracking-widest text-white/40">Refreshed hourly</span>
+              <h2 class="text-2xl font-light">Plays in motion</h2>
+              <span class="text-xs uppercase tracking-[0.4em] text-white/40">now</span>
             </div>
-            <div class="grid gap-5 md:grid-cols-2 text-sm text-white/70">
-              <div class="rounded-2xl bg-white/5 p-5 space-y-2">
-                <p class="text-white text-lg font-light">Table turns</p>
-                <p>Average 1.8 turns on weekdays; add counter seating to hit 2.1 target.</p>
+            <div class="grid gap-4 md:grid-cols-2">
+              <div class="rounded-3xl bg-gradient-to-br from-emerald-500/30 via-emerald-500/10 to-white/10 p-5">
+                <p class="text-sm uppercase tracking-[0.35em] text-white/60">this week</p>
+                <p class="mt-5 text-xl font-light">Chef counter livestream</p>
               </div>
-              <div class="rounded-2xl bg-white/5 p-5 space-y-2">
-                <p class="text-white text-lg font-light">New guests</p>
-                <p>38% of parties first-time visitors last week, boosted by Google Maps ads.</p>
+              <div class="rounded-3xl bg-gradient-to-br from-sky-500/30 via-sky-500/10 to-white/10 p-5">
+                <p class="text-sm uppercase tracking-[0.35em] text-white/60">next</p>
+                <p class="mt-5 text-xl font-light">UW finals comfort tour</p>
               </div>
-              <div class="rounded-2xl bg-white/5 p-5 space-y-2">
-                <p class="text-white text-lg font-light">Avg check</p>
-                <p>$27 dine-in (goal $28.50). Recommend dessert pairing prompts.</p>
+              <div class="rounded-3xl bg-gradient-to-br from-amber-500/30 via-amber-500/10 to-white/10 p-5">
+                <p class="text-sm uppercase tracking-[0.35em] text-white/60">later</p>
+                <p class="mt-5 text-xl font-light">Night market pop-up</p>
               </div>
-              <div class="rounded-2xl bg-white/5 p-5 space-y-2">
-                <p class="text-white text-lg font-light">Delivery satisfaction</p>
-                <p>4.8★ average on last 100 orders; packaging feedback positive after compostable switch.</p>
+              <div class="rounded-3xl bg-gradient-to-br from-rose-500/30 via-rose-500/10 to-white/10 p-5">
+                <p class="text-sm uppercase tracking-[0.35em] text-white/60">watch</p>
+                <p class="mt-5 text-xl font-light">Capitol hill takeover</p>
               </div>
             </div>
-          </article>
+          </div>
 
-          <aside class="rounded-3xl border border-white/10 bg-surface p-8 space-y-6">
-            <h2 class="text-2xl font-light">Alerts</h2>
-            <div class="space-y-4 text-sm text-white/70">
-              <div class="rounded-2xl bg-amber/10 border border-amber/30 text-amber-100 p-4 space-y-2">
-                <p class="text-xs uppercase tracking-widest">Watch</p>
-                <p>Competitor Jai Thai added late-night happy hour. Monitor impact on Friday takeout.</p>
+          <aside class="rounded-[32px] border border-white/10 bg-white/5 p-8 backdrop-blur space-y-6">
+            <h2 class="text-2xl font-light">Flow lane</h2>
+            <div class="space-y-5 text-sm text-white/70">
+              <div class="flex items-center gap-3">
+                <span class="h-10 w-10 rounded-full bg-white/10 flex items-center justify-center">A</span>
+                <div>
+                  <p class="text-white/80">Awareness</p>
+                  <div class="mt-2 h-1.5 w-32 rounded-full bg-white/20">
+                    <div class="h-full w-3/4 rounded-full bg-white/60"></div>
+                  </div>
+                </div>
               </div>
-              <div class="rounded-2xl bg-white/5 p-4 space-y-2">
-                <p class="text-xs uppercase tracking-widest text-white/40">Win</p>
-                <p>Google "Thai catering Seattle" ranking moved to position 2 after schema refresh.</p>
+              <div class="flex items-center gap-3">
+                <span class="h-10 w-10 rounded-full bg-white/10 flex items-center justify-center">B</span>
+                <div>
+                  <p class="text-white/80">Booking</p>
+                  <div class="mt-2 h-1.5 w-32 rounded-full bg-white/20">
+                    <div class="h-full w-2/3 rounded-full bg-white/60"></div>
+                  </div>
+                </div>
               </div>
-              <div class="rounded-2xl bg-white/5 p-4 space-y-2">
-                <p class="text-xs uppercase tracking-widest text-white/40">Heads-up</p>
-                <p>Weather models show rain on Saturday — prepare push notification for delivery comfort menu.</p>
+              <div class="flex items-center gap-3">
+                <span class="h-10 w-10 rounded-full bg-white/10 flex items-center justify-center">R</span>
+                <div>
+                  <p class="text-white/80">Repeat</p>
+                  <div class="mt-2 h-1.5 w-32 rounded-full bg-white/20">
+                    <div class="h-full w-4/5 rounded-full bg-white/60"></div>
+                  </div>
+                </div>
               </div>
             </div>
           </aside>
+        </section>
+
+        <section class="rounded-[32px] border border-white/10 bg-white/5 p-8 backdrop-blur">
+          <div class="flex flex-wrap items-center justify-between gap-4">
+            <h2 class="text-2xl font-light">Signal tiles</h2>
+            <span class="text-xs uppercase tracking-[0.4em] text-white/40">snapshots</span>
+          </div>
+          <div class="mt-8 grid gap-4 md:grid-cols-4 text-sm text-white/70">
+            <div class="rounded-3xl bg-white/10 p-5">
+              <p class="text-xs uppercase tracking-[0.35em] text-white/50">traffic</p>
+              <p class="mt-5 text-2xl font-light">+12%</p>
+            </div>
+            <div class="rounded-3xl bg-white/10 p-5">
+              <p class="text-xs uppercase tracking-[0.35em] text-white/50">covers</p>
+              <p class="mt-5 text-2xl font-light">164 forecast</p>
+            </div>
+            <div class="rounded-3xl bg-white/10 p-5">
+              <p class="text-xs uppercase tracking-[0.35em] text-white/50">loyalty</p>
+              <p class="mt-5 text-2xl font-light">28% reorder</p>
+            </div>
+            <div class="rounded-3xl bg-white/10 p-5">
+              <p class="text-xs uppercase tracking-[0.35em] text-white/50">reviews</p>
+              <p class="mt-5 text-2xl font-light">4.6 ★</p>
+            </div>
+          </div>
         </section>
       </main>
     </div>

--- a/human-advisor.html
+++ b/human-advisor.html
@@ -14,8 +14,6 @@
             },
             colors: {
               night: '#050505',
-              surface: 'rgba(255,255,255,0.04)',
-              accent: '#38bdf8',
             },
           },
         },
@@ -26,10 +24,15 @@
       rel="stylesheet"
       href="https://fonts.googleapis.com/css2?family=Great+Vibes&family=Inter:wght@300;400;500;600;700&display=swap"
     />
+    <style>
+      body {
+        background: #030303;
+      }
+    </style>
   </head>
   <body class="min-h-screen bg-night text-white font-sans">
-    <div class="min-h-screen px-6 md:px-12 pb-16">
-      <header class="py-8 flex items-start justify-between">
+    <div class="min-h-screen flex flex-col px-6 md:px-12 py-10">
+      <header class="flex items-start justify-between">
         <div class="space-y-4">
           <button
             onclick="window.location.href='demo.html'"
@@ -40,123 +43,91 @@
               <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M15 19l-7-7 7-7" />
             </svg>
           </button>
-          <div class="text-4xl font-script tracking-wide">genie</div>
+          <div class="text-4xl font-script tracking-wide italic">genie</div>
         </div>
         <div class="text-right">
-          <p class="uppercase tracking-[0.35em] text-xs text-white/50">Suit &amp; Thai Restaurant</p>
-          <p class="text-sm text-white/60">Advisor lounge</p>
+          <p class="uppercase tracking-[0.4em] text-xs text-white/60">your AI business advisor</p>
         </div>
       </header>
 
-      <main class="grid gap-8 lg:grid-cols-[1.1fr,0.9fr] items-start">
-        <section class="rounded-3xl border border-white/10 bg-surface p-6 space-y-6">
-          <header class="flex flex-wrap items-center justify-between gap-4">
-            <div>
-              <p class="text-xs uppercase tracking-widest text-white/40">Live session</p>
-              <h1 class="text-3xl font-light">With Nia Patel · Service Design Strategist</h1>
-            </div>
-            <button
-              type="button"
-              class="inline-flex items-center gap-2 rounded-full border border-white/40 px-5 py-2 text-sm font-medium text-white hover:border-white transition"
-            >
-              <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M15.75 5.25L8.25 12l7.5 6.75" />
-              </svg>
-              Leave room
-            </button>
-          </header>
-
-          <div class="relative rounded-2xl border border-white/10 bg-white/5 p-4">
-            <div class="aspect-video w-full rounded-xl bg-gradient-to-br from-white/10 via-white/5 to-white/0 flex items-center justify-center">
-              <div class="text-center space-y-3">
-                <div class="inline-flex items-center justify-center w-16 h-16 rounded-full bg-white/20 text-white text-2xl font-semibold">NP</div>
-                <p class="text-white/70 text-sm">Video stream placeholder · 00:12:48 elapsed</p>
-              </div>
-            </div>
-            <div class="mt-4 grid gap-3 sm:grid-cols-3 text-xs text-white/70">
-              <button class="flex items-center justify-center gap-2 rounded-full bg-white text-black py-2 font-medium hover:bg-white/80 transition">
-                <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                  <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M5 8l7-5 7 5v11a2 2 0 01-2 2H7a2 2 0 01-2-2V8z" />
-                </svg>
-                Mute
-              </button>
-              <button class="flex items-center justify-center gap-2 rounded-full border border-white/30 py-2 font-medium text-white hover:border-white transition">
-                <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                  <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M12 14l9-5-9-5-9 5 9 5z" />
-                  <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M12 14v7" />
-                </svg>
-                Share deck
-              </button>
-              <button class="flex items-center justify-center gap-2 rounded-full border border-white/30 py-2 font-medium text-white hover:border-white transition">
-                <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                  <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M12 11c.5304 0 1.0391-.2107 1.4142-.5858C13.7893 10.0391 14 9.5304 14 9s-.2107-1.0391-.5858-1.4142C13.0391 7.2107 12.5304 7 12 7s-1.0391.2107-1.4142.5858C10.2107 7.9609 10 8.4696 10 9s.2107 1.0391.5858 1.4142C10.9609 10.7893 11.4696 11 12 11zm0 3c-.5304 0-1.0391.2107-1.4142.5858C10.2107 14.9609 10 15.4696 10 16s.2107 1.0391.5858 1.4142C10.9609 17.7893 11.4696 18 12 18s1.0391-.2107 1.4142-.5858C13.7893 16.9609 14 16.4696 14 16s-.2107-1.0391-.5858-1.4142C13.0391 14.2107 12.5304 14 12 14z" />
-                </svg>
-                Action items
-              </button>
-            </div>
-          </div>
-
-          <div class="rounded-2xl border border-white/10 bg-white/5 p-5 space-y-4">
-            <h2 class="text-xl font-light">Session goals</h2>
-            <ul class="space-y-2 text-sm text-white/70">
-              <li>Refine Night Market guest journey and staffing map.</li>
-              <li>Pressure-test finals week promotions with on-campus ambassadors.</li>
-              <li>Outline hospitality touches that reinforce Golden Singha's family roots.</li>
-            </ul>
-          </div>
+      <main class="flex-1 py-10 flex flex-col gap-12">
+        <section class="max-w-4xl">
+          <h1 class="text-5xl md:text-6xl font-light">Human Advisor</h1>
+          <p class="mt-3 text-sm uppercase tracking-[0.5em] text-white/40">concierge</p>
         </section>
 
-        <aside class="rounded-3xl border border-white/10 bg-surface p-6 flex flex-col h-full">
-          <header class="flex items-center justify-between">
-            <h2 class="text-2xl font-light">Chat notes</h2>
-            <button class="inline-flex items-center justify-center rounded-full border border-white/30 w-9 h-9 text-white/70 hover:border-white transition">
-              <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M21 11.5a8.38 8.38 0 01-.9 3.8 8.5 8.5 0 01-7.6 4.7 8.38 8.38 0 01-3.8-.9L3 21l1.9-4.7a8.38 8.38 0 01-.9-3.8 8.5 8.5 0 014.7-7.6 8.38 8.38 0 013.8-.9H13a8 8 0 018 8z" />
-              </svg>
-            </button>
-          </header>
-
-          <div class="mt-6 flex-1 space-y-4 overflow-y-auto pr-2 text-sm text-white/70">
-            <div class="rounded-2xl bg-white/5 p-4 space-y-2">
-              <p class="text-xs uppercase tracking-widest text-white/40">Nia · 12:42</p>
-              <p>Finals push looks strong — consider bundling Thai tea growlers with a pre-order window to manage flow.</p>
+        <section class="grid gap-6 lg:grid-cols-[1.2fr,0.8fr]">
+          <div class="rounded-[32px] border border-white/10 bg-white/5 p-8 backdrop-blur space-y-8">
+            <div class="flex items-center justify-between">
+              <h2 class="text-2xl font-light">Team</h2>
+              <span class="text-xs uppercase tracking-[0.4em] text-white/40">available</span>
             </div>
-            <div class="rounded-2xl bg-white/5 p-4 space-y-2">
-              <p class="text-xs uppercase tracking-widest text-white/40">Bakeree · 12:44</p>
-              <p>Love that. Checking if we can prep 20 growlers without impacting dinner line. Inventory showing enough tea leaves.</p>
-            </div>
-            <div class="rounded-2xl bg-white/5 p-4 space-y-2">
-              <p class="text-xs uppercase tracking-widest text-white/40">Nia · 12:46</p>
-              <p>For Night Market, let's choreograph arrival so each guest hits the story wall first. I’ll drop a figma link.</p>
-            </div>
-            <div class="rounded-2xl bg-white/5 p-4 space-y-2">
-              <p class="text-xs uppercase tracking-widest text-white/40">Genie note</p>
-              <p>Action item added: draft signage copy for patio welcome desk.</p>
+            <div class="grid gap-4 sm:grid-cols-2 text-sm text-white/70">
+              <div class="rounded-3xl bg-gradient-to-br from-rose-500/30 via-rose-500/10 to-white/10 p-6">
+                <p class="text-xs uppercase tracking-[0.35em] text-white/60">Mila</p>
+                <p class="mt-5 text-xl font-light">Growth partner</p>
+                <p class="mt-3 text-white/50">Next check-in 2pm</p>
+              </div>
+              <div class="rounded-3xl bg-gradient-to-br from-sky-500/30 via-sky-500/10 to-white/10 p-6">
+                <p class="text-xs uppercase tracking-[0.35em] text-white/60">Noon</p>
+                <p class="mt-5 text-xl font-light">Operations</p>
+                <p class="mt-3 text-white/50">Shift sync 4pm</p>
+              </div>
+              <div class="rounded-3xl bg-gradient-to-br from-emerald-500/30 via-emerald-500/10 to-white/10 p-6">
+                <p class="text-xs uppercase tracking-[0.35em] text-white/60">Lena</p>
+                <p class="mt-5 text-xl font-light">Finance</p>
+                <p class="mt-3 text-white/50">Report drop Friday</p>
+              </div>
+              <div class="rounded-3xl bg-gradient-to-br from-purple-500/30 via-purple-500/10 to-white/10 p-6">
+                <p class="text-xs uppercase tracking-[0.35em] text-white/60">Kai</p>
+                <p class="mt-5 text-xl font-light">Experiments</p>
+                <p class="mt-3 text-white/50">Wall update 1pm</p>
+              </div>
             </div>
           </div>
 
-          <form class="mt-6 space-y-3">
-            <label class="sr-only" for="message">Message</label>
-            <textarea
-              id="message"
-              rows="3"
-              placeholder="Type a note to Nia"
-              class="w-full rounded-2xl border border-white/20 bg-transparent p-4 text-sm text-white placeholder:text-white/30 focus:border-white focus:outline-none focus:ring-0"
-            ></textarea>
-            <div class="flex items-center justify-between text-xs text-white/40">
-              <span>Shift + Enter to add line</span>
-              <button
-                type="button"
-                class="inline-flex items-center gap-2 rounded-full bg-white text-black px-5 py-2 text-sm font-medium hover:bg-white/80 transition"
-              >
-                Send
-                <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                  <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M5 12h14M12 5l7 7-7 7" />
-                </svg>
-              </button>
+          <aside class="rounded-[32px] border border-white/10 bg-white/5 p-8 backdrop-blur space-y-6">
+            <h2 class="text-2xl font-light">Contact</h2>
+            <div class="space-y-4 text-sm text-white/70">
+              <div class="rounded-3xl bg-white/10 p-4">
+                <p class="text-xs uppercase tracking-[0.35em] text-white/50">Text</p>
+                <p class="mt-2 text-white/80">(206) 555-0128</p>
+              </div>
+              <div class="rounded-3xl bg-white/10 p-4">
+                <p class="text-xs uppercase tracking-[0.35em] text-white/50">Email</p>
+                <p class="mt-2 text-white/80">hello@suitandtie.ai</p>
+              </div>
+              <div class="rounded-3xl bg-white/10 p-4">
+                <p class="text-xs uppercase tracking-[0.35em] text-white/50">Office</p>
+                <p class="mt-2 text-white/80">Remote · Seattle + SF</p>
+              </div>
             </div>
-          </form>
-        </aside>
+          </aside>
+        </section>
+
+        <section class="rounded-[32px] border border-white/10 bg-white/5 p-8 backdrop-blur">
+          <div class="flex flex-wrap items-center justify-between gap-4">
+            <h2 class="text-2xl font-light">Call board</h2>
+            <span class="text-xs uppercase tracking-[0.4em] text-white/40">queue</span>
+          </div>
+          <div class="mt-8 grid gap-4 md:grid-cols-3 text-sm text-white/70">
+            <div class="rounded-3xl bg-white/10 p-5">
+              <p class="text-xs uppercase tracking-[0.35em] text-white/50">Next</p>
+              <p class="mt-5 text-xl font-light">Night market budget</p>
+              <p class="mt-3 text-white/50">10:30am · Lena</p>
+            </div>
+            <div class="rounded-3xl bg-white/10 p-5">
+              <p class="text-xs uppercase tracking-[0.35em] text-white/50">Later</p>
+              <p class="mt-5 text-xl font-light">Influencer dinner recap</p>
+              <p class="mt-3 text-white/50">1:00pm · Mila</p>
+            </div>
+            <div class="rounded-3xl bg-white/10 p-5">
+              <p class="text-xs uppercase tracking-[0.35em] text-white/50">Queued</p>
+              <p class="mt-5 text-xl font-light">POS integration</p>
+              <p class="mt-3 text-white/50">4:30pm · Kai</p>
+            </div>
+          </div>
+        </section>
       </main>
     </div>
   </body>

--- a/inventory.html
+++ b/inventory.html
@@ -14,8 +14,6 @@
             },
             colors: {
               night: '#050505',
-              surface: 'rgba(255,255,255,0.04)',
-              accent: '#22d3ee',
             },
           },
         },
@@ -26,10 +24,15 @@
       rel="stylesheet"
       href="https://fonts.googleapis.com/css2?family=Great+Vibes&family=Inter:wght@300;400;500;600;700&display=swap"
     />
+    <style>
+      body {
+        background: #030303;
+      }
+    </style>
   </head>
   <body class="min-h-screen bg-night text-white font-sans">
-    <div class="min-h-screen px-6 md:px-12 pb-16 flex flex-col">
-      <header class="py-8 flex items-start justify-between">
+    <div class="min-h-screen flex flex-col px-6 md:px-12 py-10">
+      <header class="flex items-start justify-between">
         <div class="space-y-4">
           <button
             onclick="window.location.href='demo.html'"
@@ -40,39 +43,142 @@
               <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M15 19l-7-7 7-7" />
             </svg>
           </button>
-          <div class="text-4xl font-script tracking-wide">genie</div>
+          <div class="text-4xl font-script tracking-wide italic">genie</div>
         </div>
         <div class="text-right">
-          <p class="uppercase tracking-[0.35em] text-xs text-white/50">Suit &amp; Thai Restaurant</p>
-          <p class="text-sm text-white/60">Inventory intelligence</p>
+          <p class="uppercase tracking-[0.4em] text-xs text-white/60">your AI business advisor</p>
         </div>
       </header>
 
-      <main class="flex-1 flex items-center justify-center">
-        <div class="max-w-2xl text-center space-y-6">
-          <div class="inline-flex items-center rounded-full border border-white/20 px-4 py-2 text-xs uppercase tracking-widest text-white/50">
-            API integrations in progress
+      <main class="flex-1 py-10 flex flex-col gap-12">
+        <section class="max-w-4xl">
+          <h1 class="text-5xl md:text-6xl font-light">Inventory</h1>
+          <p class="mt-3 text-sm uppercase tracking-[0.5em] text-white/40">back-of-house</p>
+        </section>
+
+        <section class="grid gap-6 md:grid-cols-3">
+          <div class="rounded-[28px] border border-white/10 bg-white/5 p-6 backdrop-blur flex flex-col">
+            <div class="flex items-center justify-between text-xs uppercase tracking-[0.35em] text-white/60">
+              <span>Pantry</span>
+              <span class="inline-flex h-9 w-9 items-center justify-center rounded-2xl bg-white/15 text-white/80">
+                <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                  <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M3 7h18M3 12h18M3 17h18" />
+                </svg>
+              </span>
+            </div>
+            <div class="mt-6 text-4xl font-light">82%</div>
+            <div class="mt-auto grid grid-cols-2 gap-2 text-xs text-white/70">
+              <div class="rounded-2xl bg-white/10 px-3 py-2 text-center">Noodles</div>
+              <div class="rounded-2xl bg-white/10 px-3 py-2 text-center">Sauces</div>
+              <div class="rounded-2xl bg-white/10 px-3 py-2 text-center">Spices</div>
+              <div class="rounded-2xl bg-white/10 px-3 py-2 text-center">Rice</div>
+            </div>
           </div>
-          <h1 class="text-5xl font-light">Inventory syncing soon</h1>
-          <p class="text-lg text-white/60 leading-relaxed">
-            We're wiring Genie into Square for Restaurants and MarketMan so it can predict when to reorder palm sugar, fish sauce, and fresh
-            basil before you hit the red zone. Expect live variance tracking, prep guides, and waste alerts here.
-          </p>
-          <div class="rounded-3xl border border-white/10 bg-surface p-6 text-left space-y-4">
-            <h2 class="text-xl font-light text-white">Planned surface</h2>
-            <ul class="space-y-2 text-sm text-white/70">
-              <li>Daily par sheet synced with actual usage</li>
-              <li>Prep station readiness checklist with photo verification</li>
-              <li>Smart reorder alerts tied to vendor lead times</li>
-            </ul>
+
+          <div class="rounded-[28px] border border-white/10 bg-white/5 p-6 backdrop-blur flex flex-col">
+            <div class="flex items-center justify-between text-xs uppercase tracking-[0.35em] text-white/60">
+              <span>Prep</span>
+              <span class="inline-flex h-9 w-9 items-center justify-center rounded-2xl bg-white/15 text-white/80">
+                <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                  <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M12 6v12m6-6H6" />
+                </svg>
+              </span>
+            </div>
+            <div class="mt-6 text-4xl font-light">5 kits</div>
+            <div class="mt-auto flex items-end gap-2 h-16">
+              <div class="flex-1 rounded-full bg-white/15 h-6"></div>
+              <div class="flex-1 rounded-full bg-white/15 h-10"></div>
+              <div class="flex-1 rounded-full bg-white/40 h-14"></div>
+            </div>
           </div>
-          <a
-            href="demo.html"
-            class="inline-flex items-center justify-center rounded-full border border-white/40 px-6 py-3 text-sm font-medium text-white hover:border-white transition"
-          >
-            Back to home
-          </a>
-        </div>
+
+          <div class="rounded-[28px] border border-white/10 bg-white/5 p-6 backdrop-blur flex flex-col">
+            <div class="flex items-center justify-between text-xs uppercase tracking-[0.35em] text-white/60">
+              <span>Alerts</span>
+              <span class="inline-flex h-9 w-9 items-center justify-center rounded-2xl bg-white/15 text-white/80">
+                <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                  <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M12 9v2m0 4h.01M12 19a7 7 0 100-14 7 7 0 000 14z" />
+                </svg>
+              </span>
+            </div>
+            <div class="mt-6 text-4xl font-light">3 flags</div>
+            <div class="mt-auto space-y-2 text-xs text-white/60">
+              <div class="rounded-2xl bg-white/10 px-3 py-2">Thai basil low</div>
+              <div class="rounded-2xl bg-white/10 px-3 py-2">Coconut milk reorder</div>
+              <div class="rounded-2xl bg-white/10 px-3 py-2">To-go cups rush</div>
+            </div>
+          </div>
+        </section>
+
+        <section class="grid gap-6 lg:grid-cols-[1.2fr,0.8fr]">
+          <div class="rounded-[32px] border border-white/10 bg-white/5 p-8 backdrop-blur space-y-6">
+            <div class="flex items-center justify-between">
+              <h2 class="text-2xl font-light">Walk-in map</h2>
+              <span class="text-xs uppercase tracking-[0.4em] text-white/40">live temp</span>
+            </div>
+            <div class="grid gap-4 sm:grid-cols-2">
+              <div class="rounded-3xl bg-gradient-to-br from-orange-500/30 via-orange-500/10 to-white/10 p-6 text-sm text-white/70">
+                <p class="text-xs uppercase tracking-[0.35em] text-white/60">Protein</p>
+                <p class="mt-6 text-2xl font-light">36°F</p>
+              </div>
+              <div class="rounded-3xl bg-gradient-to-br from-emerald-500/30 via-emerald-500/10 to-white/10 p-6 text-sm text-white/70">
+                <p class="text-xs uppercase tracking-[0.35em] text-white/60">Veg</p>
+                <p class="mt-6 text-2xl font-light">39°F</p>
+              </div>
+              <div class="rounded-3xl bg-gradient-to-br from-sky-500/30 via-sky-500/10 to-white/10 p-6 text-sm text-white/70">
+                <p class="text-xs uppercase tracking-[0.35em] text-white/60">Prep</p>
+                <p class="mt-6 text-2xl font-light">34°F</p>
+              </div>
+              <div class="rounded-3xl bg-gradient-to-br from-fuchsia-500/30 via-fuchsia-500/10 to-white/10 p-6 text-sm text-white/70">
+                <p class="text-xs uppercase tracking-[0.35em] text-white/60">Dessert</p>
+                <p class="mt-6 text-2xl font-light">37°F</p>
+              </div>
+            </div>
+          </div>
+
+          <aside class="rounded-[32px] border border-white/10 bg-white/5 p-8 backdrop-blur space-y-6">
+            <h2 class="text-2xl font-light">Next deliveries</h2>
+            <div class="space-y-4 text-sm text-white/70">
+              <div class="flex items-center justify-between">
+                <span class="rounded-full bg-white/15 px-3 py-1 text-xs uppercase tracking-[0.35em]">today</span>
+                <span class="text-white/60">H Mart essentials</span>
+              </div>
+              <div class="flex items-center justify-between">
+                <span class="rounded-full bg-white/15 px-3 py-1 text-xs uppercase tracking-[0.35em]">+1d</span>
+                <span class="text-white/60">Produce express</span>
+              </div>
+              <div class="flex items-center justify-between">
+                <span class="rounded-full bg-white/15 px-3 py-1 text-xs uppercase tracking-[0.35em]">+3d</span>
+                <span class="text-white/60">Seafood run</span>
+              </div>
+            </div>
+          </aside>
+        </section>
+
+        <section class="rounded-[32px] border border-white/10 bg-white/5 p-8 backdrop-blur">
+          <div class="flex flex-wrap items-center justify-between gap-4">
+            <h2 class="text-2xl font-light">Par guide</h2>
+            <span class="text-xs uppercase tracking-[0.4em] text-white/40">auto sync</span>
+          </div>
+          <div class="mt-8 grid gap-4 md:grid-cols-4 text-sm text-white/70">
+            <div class="rounded-3xl bg-white/10 p-5 text-center">
+              <p class="text-xs uppercase tracking-[0.35em] text-white/50">Pad Thai</p>
+              <p class="mt-5 text-2xl font-light">x 4 trays</p>
+            </div>
+            <div class="rounded-3xl bg-white/10 p-5 text-center">
+              <p class="text-xs uppercase tracking-[0.35em] text-white/50">Curries</p>
+              <p class="mt-5 text-2xl font-light">x 6 pans</p>
+            </div>
+            <div class="rounded-3xl bg-white/10 p-5 text-center">
+              <p class="text-xs uppercase tracking-[0.35em] text-white/50">Soup</p>
+              <p class="mt-5 text-2xl font-light">x 3 pots</p>
+            </div>
+            <div class="rounded-3xl bg-white/10 p-5 text-center">
+              <p class="text-xs uppercase tracking-[0.35em] text-white/50">Dessert</p>
+              <p class="mt-5 text-2xl font-light">x 2 trays</p>
+            </div>
+          </div>
+        </section>
       </main>
     </div>
   </body>

--- a/marketing.html
+++ b/marketing.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Genie | Marketing Desk</title>
+    <title>Genie | Marketing</title>
     <script>
       tailwind.config = {
         theme: {
@@ -14,8 +14,6 @@
             },
             colors: {
               night: '#050505',
-              surface: 'rgba(255,255,255,0.04)',
-              accent: '#a855f7',
             },
           },
         },
@@ -26,10 +24,15 @@
       rel="stylesheet"
       href="https://fonts.googleapis.com/css2?family=Great+Vibes&family=Inter:wght@300;400;500;600;700&display=swap"
     />
+    <style>
+      body {
+        background: #030303;
+      }
+    </style>
   </head>
   <body class="min-h-screen bg-night text-white font-sans">
-    <div class="min-h-screen px-6 md:px-12 pb-16">
-      <header class="py-8 flex items-start justify-between">
+    <div class="min-h-screen flex flex-col px-6 md:px-12 py-10">
+      <header class="flex items-start justify-between">
         <div class="space-y-4">
           <button
             onclick="window.location.href='demo.html'"
@@ -40,233 +43,155 @@
               <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M15 19l-7-7 7-7" />
             </svg>
           </button>
-          <div class="text-4xl font-script tracking-wide">genie</div>
+          <div class="text-4xl font-script tracking-wide italic">genie</div>
         </div>
         <div class="text-right">
-          <p class="uppercase tracking-[0.35em] text-xs text-white/50">Suit &amp; Thai Restaurant</p>
-          <p class="text-sm text-white/60">Marketing control center</p>
+          <p class="uppercase tracking-[0.4em] text-xs text-white/60">your AI business advisor</p>
         </div>
       </header>
 
-      <main class="space-y-16">
-        <section class="max-w-5xl">
-          <p class="text-sm uppercase tracking-[0.4em] text-white/40">Marketing Persona</p>
-          <h1 class="mt-4 text-5xl font-light">Mila Chen — Neighborhood Growth Partner</h1>
-          <p class="mt-6 text-lg text-white/60 max-w-3xl leading-relaxed">
-            Mila blends Golden Singha Thai's warmth with data from Google, Yelp, DoorDash, and Instagram to keep Suit &amp; Thai top-of-mind for
-            University District diners. Genie keeps her briefed on what Seattle is saying, which dishes are trending, and where to place the
-            next story.
-          </p>
+      <main class="flex-1 py-10 flex flex-col gap-12">
+        <section class="max-w-4xl">
+          <h1 class="text-5xl md:text-6xl font-light">Marketing</h1>
+          <p class="mt-3 text-sm uppercase tracking-[0.5em] text-white/40">signal board</p>
         </section>
 
-        <section class="grid gap-6 lg:grid-cols-3" id="strategy">
-          <article class="lg:col-span-2 rounded-3xl border border-white/10 bg-surface p-8">
-            <div class="flex items-center justify-between">
-              <h2 class="text-2xl font-light">Current Strategy</h2>
-              <span class="text-xs uppercase tracking-widest text-white/40">Updated 4 hours ago</span>
+        <section class="grid gap-6 md:grid-cols-3">
+          <div class="rounded-[28px] border border-white/10 bg-white/5 p-6 backdrop-blur flex flex-col">
+            <div class="flex items-center justify-between text-xs uppercase tracking-[0.35em] text-white/60">
+              <span>Reach</span>
+              <span class="inline-flex h-9 w-9 items-center justify-center rounded-2xl bg-white/15 text-white/80">
+                <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                  <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M4 16l4-4 4 4 6-6" />
+                </svg>
+              </span>
             </div>
-            <div class="mt-8 grid gap-6 md:grid-cols-2">
-              <div class="rounded-2xl bg-white/5 p-6">
-                <h3 class="text-sm uppercase tracking-widest text-white/50">Core Stories</h3>
-                <ul class="mt-4 space-y-3 text-sm text-white/70 leading-relaxed">
-                  <li><span class="text-white">UW Huskies Happy Hour</span> — $12 small plates, 3–5pm, featured weekly on Instagram Reels.</li>
-                  <li><span class="text-white">Lanna Family Recipes</span> — chef spotlight series, average reel reach 11.2k with 8.3% saves.</li>
-                  <li><span class="text-white">Matcha + Mango Refreshers</span> — DoorDash promo drives +18% off-premise sales Thursdays.</li>
-                </ul>
-              </div>
-              <div class="rounded-2xl bg-white/5 p-6">
-                <h3 class="text-sm uppercase tracking-widest text-white/50">Audience Signals</h3>
-                <ul class="mt-4 space-y-3 text-sm text-white/70 leading-relaxed">
-                  <li>Google rating <span class="text-white">4.6 ★</span> on 510 reviews; "pad kee mao" cited in 27% of April mentions.</li>
-                  <li>Top delivery zip: 98105 (42% of orders). Late-night spike 10–11pm driven by UW residence halls.</li>
-                  <li>Monthly newsletter (3.2k subscribers) average CTR <span class="text-white">11.8%</span> with Spring Patio teaser.</li>
-                </ul>
-              </div>
-              <div class="rounded-2xl bg-white/5 p-6">
-                <h3 class="text-sm uppercase tracking-widest text-white/50">Channel Mix</h3>
-                <dl class="mt-4 space-y-3 text-sm text-white/70">
-                  <div class="flex items-center justify-between">
-                    <dt>Instagram</dt>
-                    <dd class="text-white">2.1k followers · 12.4k weekly reach</dd>
-                  </div>
-                  <div class="flex items-center justify-between">
-                    <dt>Google Ads</dt>
-                    <dd class="text-white">$420 spend · $11 CPA on catering leads</dd>
-                  </div>
-                  <div class="flex items-center justify-between">
-                    <dt>Influencer tables</dt>
-                    <dd class="text-white">2 comp dinners/month · 9.7% new guest lift</dd>
-                  </div>
-                </dl>
-              </div>
-              <div class="rounded-2xl bg-white/5 p-6">
-                <h3 class="text-sm uppercase tracking-widest text-white/50">Benchmark Pulse</h3>
-                <ul class="mt-4 space-y-3 text-sm text-white/70 leading-relaxed">
-                  <li>Seattle Thai restaurants average Google rating 4.3; Suit &amp; Thai outperforms on "friendly service" keyword.</li>
-                  <li>Thai Tom and Pinto Bistro increased paid search bids last week; impression share dropped 6 points.</li>
-                  <li>DoorDash loyalty conversion 18% (top quartile) with free Thai iced tea upsell.</li>
-                </ul>
-              </div>
+            <div class="mt-6 text-4xl font-light">+18%</div>
+            <div class="mt-auto flex h-20 items-end gap-1 text-white/40">
+              <div class="flex-1 rounded-full bg-white/15 h-6"></div>
+              <div class="flex-1 rounded-full bg-white/15 h-10"></div>
+              <div class="flex-1 rounded-full bg-white/15 h-14"></div>
+              <div class="flex-1 rounded-full bg-white/40 h-16"></div>
             </div>
-          </article>
-
-          <aside class="rounded-3xl border border-white/10 bg-surface p-8">
-            <h2 class="text-2xl font-light">Live KPIs</h2>
-            <dl class="mt-6 space-y-4 text-sm text-white/70">
-              <div class="flex items-center justify-between">
-                <dt>Weekend covers forecast</dt>
-                <dd class="text-white text-lg font-light">164</dd>
-              </div>
-              <div class="flex items-center justify-between">
-                <dt>DoorDash reorder rate</dt>
-                <dd class="text-white text-lg font-light">28%</dd>
-              </div>
-              <div class="flex items-center justify-between">
-                <dt>Organic search clicks (7d)</dt>
-                <dd class="text-white text-lg font-light">3.4k</dd>
-              </div>
-              <div class="flex items-center justify-between">
-                <dt>Influencer ROI (QTD)</dt>
-                <dd class="text-white text-lg font-light">4.2×</dd>
-              </div>
-            </dl>
-          </aside>
-        </section>
-
-        <section class="space-y-6">
-          <div class="flex items-center justify-between">
-            <h2 class="text-3xl font-light">AI Recommendations</h2>
-            <span class="text-xs uppercase tracking-widest text-white/40">Powered by Genie</span>
           </div>
-          <div class="grid gap-6 lg:grid-cols-3">
-            <article class="rounded-3xl border border-white/10 bg-surface p-6 flex flex-col">
-              <header>
-                <p class="text-xs uppercase tracking-[0.4em] text-white/40">Campaign</p>
-                <h3 class="mt-3 text-2xl font-light">UW Finals Comfort Tour</h3>
-              </header>
-              <p class="mt-4 text-sm text-white/70 leading-relaxed">
-                Deploy TikTok + Instagram stories featuring late-night noodle prep and study-friendly snacks. Genie projects +14% late-night
-                delivery over the next two exam weeks.
-              </p>
-              <div class="mt-5 flex flex-wrap gap-2 text-xs text-white/60">
-                <span class="rounded-full border border-white/20 px-3 py-1">Budget: $280</span>
-                <span class="rounded-full border border-white/20 px-3 py-1">ETA: 10 days</span>
-                <span class="rounded-full border border-white/20 px-3 py-1">Audience: UW Campus</span>
-              </div>
-              <div class="mt-6 flex gap-3">
-                <button type="button" class="flex-1 rounded-full bg-white text-black py-2 text-sm font-medium hover:bg-white/80 transition">
-                  Take it
-                </button>
-                <a
-                  href="experiments.html#uw-finals"
-                  class="flex-1 rounded-full border border-white/40 py-2 text-center text-sm font-medium text-white hover:border-white transition"
-                >
-                  Run experiment
-                </a>
-              </div>
-            </article>
 
-            <article class="rounded-3xl border border-white/10 bg-surface p-6 flex flex-col">
-              <header>
-                <p class="text-xs uppercase tracking-[0.4em] text-white/40">Loyalty</p>
-                <h3 class="mt-3 text-2xl font-light">Pad Thai Passport</h3>
-              </header>
-              <p class="mt-4 text-sm text-white/70 leading-relaxed">
-                Introduce a five-stamp passport redeemable for a chef's-choice dessert. Modeled on DoorDash cohorts, Genie expects a 9% boost in
-                repeat visits and 17% more Google reviews mentioning "loyalty" in 30 days.
-              </p>
-              <div class="mt-5 flex flex-wrap gap-2 text-xs text-white/60">
-                <span class="rounded-full border border-white/20 px-3 py-1">Budget: $140</span>
-                <span class="rounded-full border border-white/20 px-3 py-1">ETA: 21 days</span>
-                <span class="rounded-full border border-white/20 px-3 py-1">Channel: In-store + Email</span>
-              </div>
-              <div class="mt-6 flex gap-3">
-                <button type="button" class="flex-1 rounded-full bg-white text-black py-2 text-sm font-medium hover:bg-white/80 transition">
-                  Take it
-                </button>
-                <a
-                  href="experiments.html#pad-thai-passport"
-                  class="flex-1 rounded-full border border-white/40 py-2 text-center text-sm font-medium text-white hover:border-white transition"
-                >
-                  Run experiment
-                </a>
-              </div>
-            </article>
+          <div class="rounded-[28px] border border-white/10 bg-white/5 p-6 backdrop-blur flex flex-col">
+            <div class="flex items-center justify-between text-xs uppercase tracking-[0.35em] text-white/60">
+              <span>Stories</span>
+              <span class="inline-flex h-9 w-9 items-center justify-center rounded-2xl bg-white/15 text-white/80">
+                <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                  <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M12 6v12m6-6H6" />
+                </svg>
+              </span>
+            </div>
+            <div class="mt-6 text-4xl font-light">4 queued</div>
+            <div class="mt-auto grid grid-cols-2 gap-2 text-xs text-white/70">
+              <div class="rounded-2xl bg-white/10 px-3 py-2 text-center">UW Finals</div>
+              <div class="rounded-2xl bg-white/10 px-3 py-2 text-center">Night Market</div>
+              <div class="rounded-2xl bg-white/10 px-3 py-2 text-center">Matcha Drop</div>
+              <div class="rounded-2xl bg-white/10 px-3 py-2 text-center">Chef Lens</div>
+            </div>
+          </div>
 
-            <article class="rounded-3xl border border-white/10 bg-surface p-6 flex flex-col">
-              <header>
-                <p class="text-xs uppercase tracking-[0.4em] text-white/40">PR</p>
-                <h3 class="mt-3 text-2xl font-light">Neighborhood Night Market</h3>
-              </header>
-              <p class="mt-4 text-sm text-white/70 leading-relaxed">
-                Partner with U-District StreetFair vendors for an after-hours tasting flight featuring Golden Singha's khao soi and signature
-                Singha Spritz. Press list includes Eater Seattle and Seattle Met.
-              </p>
-              <div class="mt-5 flex flex-wrap gap-2 text-xs text-white/60">
-                <span class="rounded-full border border-white/20 px-3 py-1">Budget: $600</span>
-                <span class="rounded-full border border-white/20 px-3 py-1">ETA: 30 days</span>
-                <span class="rounded-full border border-white/20 px-3 py-1">Partners: 4 vendors</span>
+          <div class="rounded-[28px] border border-white/10 bg-white/5 p-6 backdrop-blur flex flex-col">
+            <div class="flex items-center justify-between text-xs uppercase tracking-[0.35em] text-white/60">
+              <span>Spend</span>
+              <span class="inline-flex h-9 w-9 items-center justify-center rounded-2xl bg-white/15 text-white/80">
+                <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                  <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M12 8c-1.657 0-3 .895-3 2s1.343 2 3 2 3 .895 3 2-1.343 2-3 2m0-8c1.105 0 2 .672 2 1.5S13.105 11 12 11m0-3c-1.105 0-2-.672-2-1.5S10.895 5 12 5m0 14v-2m0-10V5" />
+                </svg>
+              </span>
+            </div>
+            <div class="mt-6 text-4xl font-light">$620</div>
+            <div class="mt-auto flex justify-between text-xs text-white/60">
+              <div class="flex flex-col items-center gap-2">
+                <span class="inline-flex h-10 w-10 items-center justify-center rounded-full bg-white/10 text-white/80">IG</span>
+                <span>40%</span>
               </div>
-              <div class="mt-6 flex gap-3">
-                <button type="button" class="flex-1 rounded-full bg-white text-black py-2 text-sm font-medium hover:bg-white/80 transition">
-                  Take it
-                </button>
-                <a
-                  href="experiments.html#night-market"
-                  class="flex-1 rounded-full border border-white/40 py-2 text-center text-sm font-medium text-white hover:border-white transition"
-                >
-                  Run experiment
-                </a>
+              <div class="flex flex-col items-center gap-2">
+                <span class="inline-flex h-10 w-10 items-center justify-center rounded-full bg-white/10 text-white/80">Ads</span>
+                <span>35%</span>
               </div>
-            </article>
+              <div class="flex flex-col items-center gap-2">
+                <span class="inline-flex h-10 w-10 items-center justify-center rounded-full bg-white/10 text-white/80">PR</span>
+                <span>25%</span>
+              </div>
+            </div>
           </div>
         </section>
 
         <section class="grid gap-6 lg:grid-cols-[1.2fr,0.8fr]">
-          <article class="rounded-3xl border border-white/10 bg-surface p-8">
+          <div class="rounded-[32px] border border-white/10 bg-white/5 p-8 backdrop-blur space-y-6">
             <div class="flex items-center justify-between">
-              <h2 class="text-2xl font-light">Channel Diagnostics</h2>
-              <span class="text-xs uppercase tracking-widest text-white/40">Last 7 days</span>
+              <h2 class="text-2xl font-light">Story Stack</h2>
+              <span class="text-xs uppercase tracking-[0.4em] text-white/40">swipe ready</span>
             </div>
-            <div class="mt-6 grid gap-5 md:grid-cols-2 text-sm text-white/70">
-              <div class="rounded-2xl bg-white/5 p-5 space-y-3">
-                <h3 class="text-white text-lg font-light">Search</h3>
-                <p>
-                  <span class="text-white">+18%</span> YoY click-through on "Thai food Seattle"; Genie suggests extending ad hours to midnight during finals week.
-                </p>
+            <div class="grid gap-4 sm:grid-cols-2">
+              <div class="rounded-3xl bg-gradient-to-br from-fuchsia-500/30 via-fuchsia-500/10 to-white/10 p-5">
+                <p class="text-sm uppercase tracking-[0.35em] text-white/60">reel</p>
+                <p class="mt-6 text-xl font-light">UW Finals comfort tour</p>
               </div>
-              <div class="rounded-2xl bg-white/5 p-5 space-y-3">
-                <h3 class="text-white text-lg font-light">Social</h3>
-                <p>Reels completion rate <span class="text-white">72%</span>. "Chef Bee" series draws the highest saves and shares.</p>
+              <div class="rounded-3xl bg-gradient-to-br from-blue-500/30 via-blue-500/10 to-white/10 p-5">
+                <p class="text-sm uppercase tracking-[0.35em] text-white/60">carousel</p>
+                <p class="mt-6 text-xl font-light">Pad thai passport</p>
               </div>
-              <div class="rounded-2xl bg-white/5 p-5 space-y-3">
-                <h3 class="text-white text-lg font-light">Email</h3>
-                <p>Campaign "Songkran Brunch" delivered <span class="text-white">16% CTR</span>; experiment with segmented send times next.</p>
+              <div class="rounded-3xl bg-gradient-to-br from-emerald-500/30 via-emerald-500/10 to-white/10 p-5">
+                <p class="text-sm uppercase tracking-[0.35em] text-white/60">email</p>
+                <p class="mt-6 text-xl font-light">Neighborhood night market</p>
               </div>
-              <div class="rounded-2xl bg-white/5 p-5 space-y-3">
-                <h3 class="text-white text-lg font-light">Press</h3>
-                <p>Seattle Met's write-up still drives 190 weekly sessions; add fresh photography before Memorial Day.</p>
+              <div class="rounded-3xl bg-gradient-to-br from-amber-500/30 via-amber-500/10 to-white/10 p-5">
+                <p class="text-sm uppercase tracking-[0.35em] text-white/60">press</p>
+                <p class="mt-6 text-xl font-light">Chef noon spotlight</p>
               </div>
             </div>
-          </article>
+          </div>
 
-          <aside class="rounded-3xl border border-white/10 bg-surface p-8 space-y-6">
-            <h2 class="text-2xl font-light">Signals Feed</h2>
+          <aside class="rounded-[32px] border border-white/10 bg-white/5 p-8 backdrop-blur space-y-6">
+            <h2 class="text-2xl font-light">Beat Map</h2>
             <div class="space-y-4 text-sm text-white/70">
-              <div class="rounded-2xl bg-white/5 p-4 space-y-2">
-                <p class="text-xs uppercase tracking-widest text-white/40">Google review · 2h ago</p>
-                <p>"Golden Singha is my go-to near UW. Try the basil fried rice — perfect spice." — Marissa L.</p>
+              <div class="flex items-center justify-between">
+                <span class="rounded-full bg-white/15 px-3 py-1 text-xs uppercase tracking-[0.35em]">today</span>
+                <span class="text-white/60">Chef live Q&amp;A</span>
               </div>
-              <div class="rounded-2xl bg-white/5 p-4 space-y-2">
-                <p class="text-xs uppercase tracking-widest text-white/40">TikTok mention · 6h ago</p>
-                <p>@seattlespoon clocked 38k views featuring your mango sticky rice; comments ask for vegan options.</p>
+              <div class="flex items-center justify-between">
+                <span class="rounded-full bg-white/15 px-3 py-1 text-xs uppercase tracking-[0.35em]">+2d</span>
+                <span class="text-white/60">Finals care kits</span>
               </div>
-              <div class="rounded-2xl bg-white/5 p-4 space-y-2">
-                <p class="text-xs uppercase tracking-widest text-white/40">DoorDash trend · 1d ago</p>
-                <p>Prep time flagged at 42 minutes on Fridays. Recommend staging curry paste pre-late rush.</p>
+              <div class="flex items-center justify-between">
+                <span class="rounded-full bg-white/15 px-3 py-1 text-xs uppercase tracking-[0.35em]">+5d</span>
+                <span class="text-white/60">Influencer tasting</span>
+              </div>
+              <div class="flex items-center justify-between">
+                <span class="rounded-full bg-white/15 px-3 py-1 text-xs uppercase tracking-[0.35em]">+8d</span>
+                <span class="text-white/60">Email drop</span>
               </div>
             </div>
           </aside>
+        </section>
+
+        <section class="rounded-[32px] border border-white/10 bg-white/5 p-8 backdrop-blur">
+          <div class="flex flex-wrap items-center justify-between gap-4">
+            <h2 class="text-2xl font-light">Channel Pulse</h2>
+            <span class="text-xs uppercase tracking-[0.4em] text-white/40">auto refresh</span>
+          </div>
+          <div class="mt-8 grid gap-6 md:grid-cols-4 text-center text-sm text-white/70">
+            <div class="space-y-4">
+              <div class="mx-auto h-20 w-20 rounded-full border border-white/20 bg-white/10 flex items-center justify-center text-3xl font-light">2.4k</div>
+              <p>IG follows</p>
+            </div>
+            <div class="space-y-4">
+              <div class="mx-auto h-20 w-20 rounded-full border border-white/20 bg-white/10 flex items-center justify-center text-3xl font-light">11.8%</div>
+              <p>Email CTR</p>
+            </div>
+            <div class="space-y-4">
+              <div class="mx-auto h-20 w-20 rounded-full border border-white/20 bg-white/10 flex items-center justify-center text-3xl font-light">28</div>
+              <p>Reviews</p>
+            </div>
+            <div class="space-y-4">
+              <div class="mx-auto h-20 w-20 rounded-full border border-white/20 bg-white/10 flex items-center justify-center text-3xl font-light">4.2×</div>
+              <p>ROI</p>
+            </div>
+          </div>
         </section>
       </main>
     </div>


### PR DESCRIPTION
## Summary
- restyle the demo hub with a cleaner greeting, simplified app tiles, and brighter gradients
- refresh each app screen with dark backgrounds, minimal card-based layouts, and updated copy
- rebuild the experiments view with an add-experiment flow that spawns editable cards with result and evidence branches

## Testing
- no automated tests were run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68d16d2def28832fbabfe9a80c1a9bb0