### PR TITLE
Revamp demo experience and app pages

### DIFF
--- a/ai-companion.html
+++ b/ai-companion.html
@@ -1,0 +1,136 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Genie | Copilot</title>
+    <script>
+      tailwind.config = {
+        theme: {
+          extend: {
+            fontFamily: {
+              script: ['"Dancing Script"', 'cursive'],
+              sans: ['"Manrope"', 'system-ui', 'sans-serif'],
+            },
+            colors: {
+              night: '#f5f6fb',
+              ink: '#0f172a',
+              bubble: '#1e293b',
+            },
+          },
+        },
+      };
+    </script>
+    <script src="https://cdn.tailwindcss.com"></script>
+    <link
+      rel="stylesheet"
+      href="https://fonts.googleapis.com/css2?family=Dancing+Script:wght@500;600&family=Manrope:wght@400;500;600;700&display=swap"
+    />
+  </head>
+  <body class="min-h-screen bg-night text-ink font-sans">
+    <div class="min-h-screen flex flex-col">
+      <header class="px-6 md:px-12 pt-8 pb-6 flex items-center justify-between">
+        <div class="flex items-center gap-4">
+          <button
+            onclick="window.location.href='demo.html'"
+            class="inline-flex items-center justify-center w-11 h-11 rounded-full border border-ink/10 text-ink hover:bg-ink/10 transition"
+            aria-label="Back to apps"
+          >
+            <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" class="w-5 h-5">
+              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M15 19l-7-7 7-7" />
+            </svg>
+          </button>
+          <div>
+            <div class="text-4xl font-script leading-none text-ink">genie</div>
+            <p class="text-sm text-ink/60">Copilot assistant</p>
+          </div>
+        </div>
+        <div class="text-right text-sm text-ink/60">Suit and Thai · Always-on</div>
+      </header>
+
+      <main class="flex-1 px-6 md:px-12 pb-6">
+        <div class="mx-auto max-w-4xl h-full flex flex-col rounded-3xl border border-ink/10 bg-white shadow-xl">
+          <div class="px-6 md:px-10 py-6 border-b border-ink/10 flex items-center justify-between">
+            <div>
+              <h1 class="text-2xl font-semibold">Ask Genie anything</h1>
+              <p class="text-sm text-ink/60">Insights grounded in your marketing, growth, and sentiment data.</p>
+            </div>
+            <div class="inline-flex items-center gap-2 rounded-full border border-ink/10 px-3 py-1 text-xs text-ink/60">
+              <span class="h-2 w-2 rounded-full bg-emerald-500"></span>
+              Live
+            </div>
+          </div>
+
+          <div class="flex-1 overflow-y-auto px-6 md:px-10 py-8 space-y-6 text-sm">
+            <div class="space-y-2">
+              <p class="text-xs uppercase tracking-wide text-ink/40">You · 9:18</p>
+              <div class="max-w-xl rounded-2xl border border-ink/10 bg-ink/5 px-5 py-4 text-ink/80">
+                What did we learn from the Chef counter livestream?
+              </div>
+            </div>
+            <div class="space-y-2">
+              <p class="text-xs uppercase tracking-wide text-ink/40">Genie · 9:18</p>
+              <div class="max-w-2xl rounded-2xl bg-bubble text-white px-5 py-4">
+                <p class="font-semibold">Livestream recap</p>
+                <ul class="mt-2 list-disc space-y-1 pl-4 text-sm">
+                  <li>251 peak viewers with average watch time of 6m 12s (25% above goal).</li>
+                  <li>72 live chat comments → 19 same-night reservations.</li>
+                  <li>Menu spotlight: pad kee mao + mango sticky rice drove 42% of orders.</li>
+                  <li>Recommendation: clip the best Q&amp;A moments into a TikTok duet series.</li>
+                </ul>
+              </div>
+            </div>
+            <div class="space-y-2">
+              <p class="text-xs uppercase tracking-wide text-ink/40">You · 9:21</p>
+              <div class="max-w-xl rounded-2xl border border-ink/10 bg-ink/5 px-5 py-4 text-ink/80">
+                Suggest a follow-up experiment to capture late night demand.
+              </div>
+            </div>
+            <div class="space-y-2">
+              <p class="text-xs uppercase tracking-wide text-ink/40">Genie · 9:21</p>
+              <div class="max-w-2xl rounded-2xl bg-bubble text-white px-5 py-4 space-y-2">
+                <p class="font-semibold">Experiment: Midnight Market Beta</p>
+                <p>
+                  Offer a limited "study break" bundle from 9:30p–11p with dual-channel promo (TikTok + SMS). Cap at 45 bundles to test ops throughput.
+                </p>
+                <div class="rounded-2xl bg-white/10 px-4 py-3 text-sm">
+                  <p class="font-medium">Next steps</p>
+                  <ul class="mt-2 list-disc space-y-1 pl-4">
+                    <li>Auto-sync to Experiments board</li>
+                    <li>Prep queue script for floor leads</li>
+                    <li>Collect post-order 1-question pulse</li>
+                  </ul>
+                </div>
+              </div>
+            </div>
+          </div>
+
+          <form class="border-t border-ink/10 px-6 md:px-10 py-5 space-y-3" onsubmit="event.preventDefault();">
+            <div class="flex flex-wrap items-center justify-between gap-3 text-xs text-ink/50">
+              <span>Genie responds with Suit and Thai data, refreshed hourly.</span>
+              <button type="button" class="inline-flex items-center gap-2 rounded-full border border-ink/10 px-3 py-1 hover:bg-ink/5 transition">
+                <svg xmlns="http://www.w3.org/2000/svg" class="h-3.5 w-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                  <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M7 16V4m0 0L3 8m4-4l4 4" />
+                </svg>
+                Pull latest data
+              </button>
+            </div>
+            <div class="flex items-end gap-3">
+              <textarea
+                rows="2"
+                class="flex-1 rounded-2xl border border-ink/10 bg-white px-4 py-3 text-sm text-ink focus:border-ink/40 focus:outline-none"
+                placeholder="Ask Genie anything…"
+              ></textarea>
+              <button type="submit" class="inline-flex items-center gap-2 rounded-full bg-ink text-white px-6 py-3 text-sm font-semibold hover:bg-ink/80 transition">
+                Send
+                <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                  <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M5 12h14M12 5l7 7-7 7" />
+                </svg>
+              </button>
+            </div>
+          </form>
+        </div>
+      </main>
+    </div>
+  </body>
+</html>

--- a/competitors.html
+++ b/competitors.html
@@ -9,11 +9,13 @@
         theme: {
           extend: {
             fontFamily: {
-              script: ['"Great Vibes"', 'cursive'],
-              sans: ['"Inter"', 'system-ui', 'sans-serif'],
+              script: ['"Dancing Script"', 'cursive'],
+              sans: ['"Manrope"', 'system-ui', 'sans-serif'],
             },
             colors: {
-              night: '#050505',
+              night: '#070711',
+              surface: 'rgba(17, 22, 42, 0.65)',
+              outline: 'rgba(255,255,255,0.12)',
             },
           },
         },
@@ -22,11 +24,16 @@
     <script src="https://cdn.tailwindcss.com"></script>
     <link
       rel="stylesheet"
-      href="https://fonts.googleapis.com/css2?family=Great+Vibes&family=Inter:wght@300;400;500;600;700&display=swap"
+      href="https://fonts.googleapis.com/css2?family=Dancing+Script:wght@500;600&family=Manrope:wght@400;500;600;700&display=swap"
     />
     <style>
       body {
-        background: #030303;
+        background: radial-gradient(circle at top left, rgba(59, 130, 246, 0.18), transparent 45%),
+          radial-gradient(circle at top right, rgba(147, 51, 234, 0.16), transparent 50%), #050508;
+      }
+      .scroll-smooth-touch {
+        scroll-snap-type: x mandatory;
+        -webkit-overflow-scrolling: touch;
       }
     </style>
   </head>
@@ -36,137 +43,202 @@
         <div class="space-y-4">
           <button
             onclick="window.location.href='demo.html'"
-            class="inline-flex items-center justify-center w-11 h-11 rounded-full border border-white/20 text-white hover:border-white/60 transition"
+            class="inline-flex items-center justify-center w-11 h-11 rounded-full border border-white/25 bg-white/5 text-white hover:border-white/60 transition"
             aria-label="Back to apps"
           >
             <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" class="w-5 h-5">
               <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M15 19l-7-7 7-7" />
             </svg>
           </button>
-          <div class="text-4xl font-script tracking-wide italic">genie</div>
+          <div class="text-4xl font-script leading-none text-white">genie</div>
         </div>
         <div class="text-right">
-          <p class="uppercase tracking-[0.4em] text-xs text-white/60">your AI business advisor</p>
+          <p class="text-sm text-white/70">Your AI business advisor</p>
         </div>
       </header>
 
       <main class="flex-1 py-10 flex flex-col gap-12">
         <section class="max-w-4xl">
           <h1 class="text-5xl md:text-6xl font-light">Competitors</h1>
-          <p class="mt-3 text-sm uppercase tracking-[0.5em] text-white/40">spotlight</p>
+          <p class="mt-3 text-base text-white/70">Swipe through the landscape and tap insights to act.</p>
         </section>
 
-        <section class="grid gap-6 md:grid-cols-3">
-          <div class="rounded-[28px] border border-white/10 bg-white/5 p-6 backdrop-blur flex flex-col">
-            <div class="flex items-center justify-between text-xs uppercase tracking-[0.35em] text-white/60">
-              <span>Thai Tom</span>
-              <span class="inline-flex h-9 w-9 items-center justify-center rounded-2xl bg-white/15 text-white/80">
-                <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                  <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M12 6l8 4-8 4-8-4 8-4z" />
-                </svg>
-              </span>
-            </div>
-            <div class="mt-6 text-4xl font-light">4.6 ★</div>
-            <div class="mt-auto flex items-center justify-between text-xs text-white/60">
-              <span class="rounded-full bg-white/10 px-3 py-1">30 min wait</span>
-              <span class="text-white/40">+9% buzz</span>
-            </div>
-          </div>
-
-          <div class="rounded-[28px] border border-white/10 bg-white/5 p-6 backdrop-blur flex flex-col">
-            <div class="flex items-center justify-between text-xs uppercase tracking-[0.35em] text-white/60">
-              <span>Pinto Bistro</span>
-              <span class="inline-flex h-9 w-9 items-center justify-center rounded-2xl bg-white/15 text-white/80">
-                <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                  <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M3 12h18" />
-                </svg>
-              </span>
-            </div>
-            <div class="mt-6 text-4xl font-light">4.4 ★</div>
-            <div class="mt-auto flex items-center justify-between text-xs text-white/60">
-              <span class="rounded-full bg-white/10 px-3 py-1">Paid ads +6%</span>
-              <span class="text-white/40">watch</span>
-            </div>
-          </div>
-
-          <div class="rounded-[28px] border border-white/10 bg-white/5 p-6 backdrop-blur flex flex-col">
-            <div class="flex items-center justify-between text-xs uppercase tracking-[0.35em] text-white/60">
-              <span>Lanna House</span>
-              <span class="inline-flex h-9 w-9 items-center justify-center rounded-2xl bg-white/15 text-white/80">
-                <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                  <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M5 12l5 5L20 7" />
-                </svg>
-              </span>
-            </div>
-            <div class="mt-6 text-4xl font-light">4.7 ★</div>
-            <div class="mt-auto flex items-center justify-between text-xs text-white/60">
-              <span class="rounded-full bg-white/10 px-3 py-1">New patio</span>
-              <span class="text-white/40">opening</span>
-            </div>
-          </div>
-        </section>
-
-        <section class="grid gap-6 lg:grid-cols-[1.2fr,0.8fr]">
-          <div class="rounded-[32px] border border-white/10 bg-white/5 p-8 backdrop-blur space-y-6">
-            <div class="flex items-center justify-between">
-              <h2 class="text-2xl font-light">Share of voice</h2>
-              <span class="text-xs uppercase tracking-[0.4em] text-white/40">30d</span>
-            </div>
-            <div class="grid gap-4 sm:grid-cols-3 text-sm text-white/70">
-              <div class="rounded-3xl bg-gradient-to-br from-blue-500/30 via-blue-500/10 to-white/10 p-5">
-                <p class="text-xs uppercase tracking-[0.35em] text-white/60">Search</p>
-                <p class="mt-5 text-2xl font-light">42%</p>
-              </div>
-              <div class="rounded-3xl bg-gradient-to-br from-emerald-500/30 via-emerald-500/10 to-white/10 p-5">
-                <p class="text-xs uppercase tracking-[0.35em] text-white/60">Social</p>
-                <p class="mt-5 text-2xl font-light">33%</p>
-              </div>
-              <div class="rounded-3xl bg-gradient-to-br from-amber-500/30 via-amber-500/10 to-white/10 p-5">
-                <p class="text-xs uppercase tracking-[0.35em] text-white/60">Press</p>
-                <p class="mt-5 text-2xl font-light">25%</p>
-              </div>
-            </div>
-          </div>
-
-          <aside class="rounded-[32px] border border-white/10 bg-white/5 p-8 backdrop-blur space-y-6">
-            <h2 class="text-2xl font-light">Moves to watch</h2>
-            <div class="space-y-4 text-sm text-white/70">
-              <div class="flex items-center justify-between">
-                <span class="rounded-full bg-white/15 px-3 py-1 text-xs uppercase tracking-[0.35em]">Thai Tom</span>
-                <span class="text-white/60">Late-night menu drop</span>
-              </div>
-              <div class="flex items-center justify-between">
-                <span class="rounded-full bg-white/15 px-3 py-1 text-xs uppercase tracking-[0.35em]">Pinto</span>
-                <span class="text-white/60">SEM bid hike</span>
-              </div>
-              <div class="flex items-center justify-between">
-                <span class="rounded-full bg-white/15 px-3 py-1 text-xs uppercase tracking-[0.35em]">Lanna</span>
-                <span class="text-white/60">Influencer dinners</span>
-              </div>
-            </div>
-          </aside>
-        </section>
-
-        <section class="rounded-[32px] border border-white/10 bg-white/5 p-8 backdrop-blur">
+        <section class="rounded-[32px] border border-outline/60 bg-surface backdrop-blur-xl p-8 space-y-8">
           <div class="flex flex-wrap items-center justify-between gap-4">
-            <h2 class="text-2xl font-light">Positioning map</h2>
-            <span class="text-xs uppercase tracking-[0.4em] text-white/40">live</span>
+            <h2 class="text-2xl font-semibold">Comparison rail</h2>
+            <div class="relative">
+              <button
+                id="competitor-ai-button"
+                class="inline-flex items-center gap-2 rounded-full bg-rose-500 px-4 py-2 text-sm font-semibold shadow-lg hover:bg-rose-400 transition"
+                type="button"
+              >
+                <span class="inline-block h-2 w-2 rounded-full bg-white animate-pulse"></span>
+                AI suggestion
+              </button>
+              <div
+                id="competitor-ai-menu"
+                class="absolute right-0 mt-3 hidden w-48 rounded-2xl border border-white/20 bg-night/95 p-3 text-sm shadow-2xl"
+              >
+                <button class="menu-option flex w-full items-center gap-2 rounded-xl px-3 py-2 text-left text-white/80 hover:bg-white/10" data-action="change">
+                  <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.6" d="M4 7h16M4 12h16m-8 5h8" />
+                  </svg>
+                  Change positioning
+                </button>
+                <button class="menu-option flex w-full items-center gap-2 rounded-xl px-3 py-2 text-left text-white/80 hover:bg-white/10" data-action="experiment">
+                  <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.6" d="M12 6v12m6-6H6" />
+                  </svg>
+                  Add to experiment
+                </button>
+              </div>
+            </div>
           </div>
-          <div class="mt-8 h-64 rounded-3xl border border-white/15 bg-white/5 relative overflow-hidden">
-            <div class="absolute inset-6 grid grid-cols-3 grid-rows-3 gap-4">
-              <div class="rounded-2xl border border-white/15"></div>
-              <div class="rounded-2xl border border-white/15"></div>
-              <div class="rounded-2xl border border-white/15"></div>
-              <div class="rounded-2xl border border-white/15"></div>
-              <div class="rounded-2xl border border-white/15 bg-gradient-to-br from-fuchsia-500/40 via-fuchsia-500/20 to-white/10 flex items-center justify-center text-sm uppercase tracking-[0.35em]">Suit &amp; Tie</div>
-              <div class="rounded-2xl border border-white/15"></div>
-              <div class="rounded-2xl border border-white/15"></div>
-              <div class="rounded-2xl border border-white/15"></div>
-              <div class="rounded-2xl border border-white/15"></div>
+
+          <div class="-mx-2 overflow-x-auto scroll-smooth-touch pb-4">
+            <div class="flex gap-6 px-2">
+              <article class="snap-start shrink-0 min-w-[260px] rounded-[28px] border border-outline bg-white/5 p-6">
+                <div class="flex items-center justify-between">
+                  <h3 class="text-xl font-semibold">Thai Tom</h3>
+                  <span class="rounded-full bg-white/10 px-3 py-1 text-xs text-white/70">4.6 ★</span>
+                </div>
+                <p class="mt-4 text-sm text-white/70">Iconic counter spot with cult lines. Recent late-night menu drop drove a 9% buzz lift.</p>
+                <dl class="mt-5 space-y-2 text-sm text-white/75">
+                  <div class="flex items-center justify-between">
+                    <dt>Wait time</dt>
+                    <dd class="rounded-full bg-white/10 px-3 py-1 text-xs">30 min</dd>
+                  </div>
+                  <div class="flex items-center justify-between">
+                    <dt>Avg check</dt>
+                    <dd class="rounded-full bg-white/10 px-3 py-1 text-xs">$19</dd>
+                  </div>
+                  <div class="flex items-center justify-between">
+                    <dt>Signature play</dt>
+                    <dd class="rounded-full bg-white/10 px-3 py-1 text-xs">Late-night wok show</dd>
+                  </div>
+                </dl>
+              </article>
+
+              <article class="snap-start shrink-0 min-w-[260px] rounded-[28px] border border-outline bg-white/5 p-6">
+                <div class="flex items-center justify-between">
+                  <h3 class="text-xl font-semibold">Pinto Bistro</h3>
+                  <span class="rounded-full bg-white/10 px-3 py-1 text-xs text-white/70">4.4 ★</span>
+                </div>
+                <p class="mt-4 text-sm text-white/70">Neighborhood favorite leaning into high-touch PR. Paid ads up 6% with brunch collabs.</p>
+                <dl class="mt-5 space-y-2 text-sm text-white/75">
+                  <div class="flex items-center justify-between">
+                    <dt>Wait time</dt>
+                    <dd class="rounded-full bg-white/10 px-3 py-1 text-xs">15 min</dd>
+                  </div>
+                  <div class="flex items-center justify-between">
+                    <dt>Avg check</dt>
+                    <dd class="rounded-full bg-white/10 px-3 py-1 text-xs">$24</dd>
+                  </div>
+                  <div class="flex items-center justify-between">
+                    <dt>Signature play</dt>
+                    <dd class="rounded-full bg-white/10 px-3 py-1 text-xs">Chef tasting nights</dd>
+                  </div>
+                </dl>
+              </article>
+
+              <article class="snap-start shrink-0 min-w-[260px] rounded-[28px] border border-outline bg-white/5 p-6">
+                <div class="flex items-center justify-between">
+                  <h3 class="text-xl font-semibold">Lanna House</h3>
+                  <span class="rounded-full bg-white/10 px-3 py-1 text-xs text-white/70">4.7 ★</span>
+                </div>
+                <p class="mt-4 text-sm text-white/70">Elevated dining with patio expansion underway. Influencer dinner series launching.</p>
+                <dl class="mt-5 space-y-2 text-sm text-white/75">
+                  <div class="flex items-center justify-between">
+                    <dt>Wait time</dt>
+                    <dd class="rounded-full bg-white/10 px-3 py-1 text-xs">20 min</dd>
+                  </div>
+                  <div class="flex items-center justify-between">
+                    <dt>Avg check</dt>
+                    <dd class="rounded-full bg-white/10 px-3 py-1 text-xs">$32</dd>
+                  </div>
+                  <div class="flex items-center justify-between">
+                    <dt>Signature play</dt>
+                    <dd class="rounded-full bg-white/10 px-3 py-1 text-xs">Garden patio parties</dd>
+                  </div>
+                </dl>
+              </article>
+
+              <article class="snap-start shrink-0 min-w-[260px] rounded-[28px] border border-outline bg-white/5 p-6">
+                <div class="flex items-center justify-between">
+                  <h3 class="text-xl font-semibold">Kin Khao Express</h3>
+                  <span class="rounded-full bg-white/10 px-3 py-1 text-xs text-white/70">4.5 ★</span>
+                </div>
+                <p class="mt-4 text-sm text-white/70">Ghost-kitchen forward with speedy delivery. Experimenting with heat-and-serve kits.</p>
+                <dl class="mt-5 space-y-2 text-sm text-white/75">
+                  <div class="flex items-center justify-between">
+                    <dt>Wait time</dt>
+                    <dd class="rounded-full bg-white/10 px-3 py-1 text-xs">Delivery only</dd>
+                  </div>
+                  <div class="flex items-center justify-between">
+                    <dt>Avg check</dt>
+                    <dd class="rounded-full bg-white/10 px-3 py-1 text-xs">$27</dd>
+                  </div>
+                  <div class="flex items-center justify-between">
+                    <dt>Signature play</dt>
+                    <dd class="rounded-full bg-white/10 px-3 py-1 text-xs">Family heat kits</dd>
+                  </div>
+                </dl>
+              </article>
+            </div>
+          </div>
+
+          <div class="rounded-[28px] border border-outline bg-white/5 p-7 space-y-6">
+            <div class="flex flex-wrap items-center justify-between gap-4">
+              <h3 class="text-xl font-semibold">Signals dashboard</h3>
+              <span class="text-sm text-white/60">Source: public reviews · social listening</span>
+            </div>
+            <div class="grid gap-6 md:grid-cols-4 text-center text-sm text-white/75">
+              <div class="rounded-2xl bg-white/5 p-5">
+                <p class="text-sm font-semibold text-white/80">Search share</p>
+                <p class="mt-3 text-2xl font-semibold">42%</p>
+                <p class="mt-2 text-xs text-emerald-300">Suit &amp; Thai +3%</p>
+              </div>
+              <div class="rounded-2xl bg-white/5 p-5">
+                <p class="text-sm font-semibold text-white/80">Social buzz</p>
+                <p class="mt-3 text-2xl font-semibold">33%</p>
+                <p class="mt-2 text-xs text-emerald-300">Chef content trending</p>
+              </div>
+              <div class="rounded-2xl bg-white/5 p-5">
+                <p class="text-sm font-semibold text-white/80">Press hits</p>
+                <p class="mt-3 text-2xl font-semibold">25%</p>
+                <p class="mt-2 text-xs text-emerald-300">Night Market story pending</p>
+              </div>
+              <div class="rounded-2xl bg-white/5 p-5">
+                <p class="text-sm font-semibold text-white/80">Sentiment</p>
+                <p class="mt-3 text-2xl font-semibold">4.6 ★</p>
+                <p class="mt-2 text-xs text-emerald-300">Friendly + pad kee mao keywords</p>
+              </div>
             </div>
           </div>
         </section>
       </main>
     </div>
+
+    <script>
+      const aiButton = document.getElementById('competitor-ai-button');
+      const aiMenu = document.getElementById('competitor-ai-menu');
+      aiButton?.addEventListener('click', (event) => {
+        event.stopPropagation();
+        aiMenu.classList.toggle('hidden');
+      });
+      document.addEventListener('click', (event) => {
+        if (!aiMenu.contains(event.target) && !aiButton.contains(event.target)) {
+          aiMenu.classList.add('hidden');
+        }
+      });
+      const competitorOptions = document.querySelectorAll('#competitor-ai-menu .menu-option');
+      competitorOptions.forEach((option) => {
+        option.addEventListener('click', () => {
+          aiMenu.classList.add('hidden');
+          const action = option.dataset.action;
+          alert(action === 'change' ? 'Genie drafted a repositioning outline.' : 'Competitor idea saved to Experiments.');
+        });
+      });
+    </script>
   </body>
 </html>

--- a/demo.html
+++ b/demo.html
@@ -9,12 +9,12 @@
         theme: {
           extend: {
             fontFamily: {
-              script: ['"Great Vibes"', 'cursive'],
-              sans: ['"Inter"', 'system-ui', 'sans-serif'],
+              script: ['"Dancing Script"', 'cursive'],
+              sans: ['"Manrope"', 'system-ui', 'sans-serif'],
             },
             colors: {
-              night: '#060606',
-              muted: '#a0a0a0',
+              night: '#070711',
+              muted: '#b4b6c8',
             },
           },
         },
@@ -23,186 +23,188 @@
     <script src="https://cdn.tailwindcss.com"></script>
     <link
       rel="stylesheet"
-      href="https://fonts.googleapis.com/css2?family=Great+Vibes&family=Inter:wght@300;400;500;600&display=swap"
+      href="https://fonts.googleapis.com/css2?family=Dancing+Script:wght@500;600&family=Manrope:wght@400;500;600;700&display=swap"
     />
     <style>
       body {
-        background: #030303;
+        background: radial-gradient(circle at top, rgba(88, 76, 255, 0.14), transparent 45%), #050508;
       }
     </style>
   </head>
   <body class="min-h-screen bg-night text-white font-sans">
     <div class="min-h-screen flex flex-col">
-      <header class="px-6 md:px-12 pt-8 flex items-start justify-between">
-        <div>
-          <button
-            onclick="window.location.href='demo.html'"
-            class="mb-4 inline-flex items-center justify-center w-11 h-11 rounded-full border border-white/20 text-white hover:border-white/60 transition"
-            aria-label="Home"
-          >
+      <header class="px-6 md:px-12 pt-10 flex items-start justify-between">
+        <div class="flex flex-col gap-5">
+          <span class="inline-flex items-center justify-center w-11 h-11 rounded-full border border-white/25 bg-white/5 text-white/90">
             <svg
               xmlns="http://www.w3.org/2000/svg"
               viewBox="0 0 24 24"
               fill="none"
               stroke="currentColor"
-              stroke-width="1.5"
+              stroke-width="1.6"
               class="w-5 h-5"
             >
-              <path
-                stroke-linecap="round"
-                stroke-linejoin="round"
-                d="M4 6h16M4 12h16M4 18h16"
-              />
+              <path stroke-linecap="round" stroke-linejoin="round" d="M3 10.5L12 4l9 6.5V20a1 1 0 01-1 1h-5.5a.5.5 0 01-.5-.5V15a2 2 0 00-2-2h-1a2 2 0 00-2 2v5.5a.5.5 0 01-.5.5H4a1 1 0 01-1-1v-9.5z" />
             </svg>
-          </button>
-          <div class="text-4xl md:text-5xl font-script tracking-wide italic">genie</div>
+          </span>
+          <div class="text-5xl md:text-6xl font-script leading-none text-white">genie</div>
         </div>
         <div class="text-right">
-          <p class="uppercase tracking-[0.4em] text-xs text-white/60">your AI business advisor</p>
+          <p class="text-sm text-white/70">Your AI business advisor</p>
         </div>
       </header>
 
       <main class="flex-1 px-6 md:px-12 py-16">
         <section class="max-w-4xl">
-          <h1 class="text-5xl md:text-6xl font-light mb-2">Hi Suit &amp; Tie</h1>
-          <p class="text-sm uppercase tracking-[0.5em] text-white/40">tap an app to dive in</p>
+          <h1 class="text-5xl md:text-6xl font-light mb-3">Hi Suit and Thai !!!</h1>
+          <p class="text-base text-white/70">Tap an app to dive in.</p>
         </section>
 
         <section class="mt-16">
           <h2 class="sr-only">Apps</h2>
-          <div class="grid gap-5 grid-cols-2 md:grid-cols-3 xl:grid-cols-4 auto-rows-[200px]">
+          <div class="mx-auto max-w-6xl grid gap-6 grid-cols-2 md:grid-cols-3 xl:grid-cols-4 auto-rows-[210px]">
             <a
               href="marketing.html"
-              class="group relative flex flex-col justify-between overflow-hidden rounded-[26px] border border-white/10 bg-gradient-to-br from-fuchsia-500/30 via-fuchsia-500/10 to-white/5 p-6 backdrop-blur transition hover:-translate-y-1 hover:border-white/40"
+              class="group relative flex flex-col justify-between overflow-hidden rounded-[22px] border border-white/20 bg-gradient-to-br from-pink-500/50 via-fuchsia-500/30 to-indigo-400/30 p-6 backdrop-blur-lg transition hover:-translate-y-1 hover:shadow-[0_20px_45px_-25px_rgba(255,0,128,0.75)]"
             >
               <div class="flex items-start justify-between">
-                <span class="inline-flex h-11 w-11 items-center justify-center rounded-2xl bg-white/20 text-white/90">
+                <span class="inline-flex h-11 w-11 items-center justify-center rounded-2xl bg-white/15 text-white/95">
                   <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M12 8c-1.105 0-2 .672-2 1.5S10.895 11 12 11m0-3c1.105 0 2 .672 2 1.5S13.105 12 12 12m0 0c-1.105 0-2 .672-2 1.5S10.895 15 12 15m0-3c1.105 0 2 .672 2 1.5S13.105 15 12 15m0 3v-3m0-6V6" />
+                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M12 8c-1.105 0-2 .672-2 1.5S10.895 12 12 12m0-3c1.105 0 2 .672 2 1.5S13.105 12 12 12m0 0c-1.105 0-2 .672-2 1.5S10.895 15 12 15m0-3c1.105 0 2 .672 2 1.5S13.105 15 12 15m0 3v-3m0-6V6" />
                   </svg>
                 </span>
-                <svg class="h-5 w-5 text-white/60 transition group-hover:translate-x-1" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                <svg class="h-5 w-5 text-white/70 transition group-hover:translate-x-1" fill="none" viewBox="0 0 24 24" stroke="currentColor">
                   <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M9 5l7 7-7 7" />
                 </svg>
               </div>
-              <h3 class="text-2xl font-medium tracking-tight">Marketing</h3>
-              <p class="text-xs uppercase tracking-[0.3em] text-white/70">open</p>
+              <h3 class="text-2xl font-semibold tracking-tight">Marketing</h3>
             </a>
 
             <a
               href="growth.html"
-              class="group relative flex flex-col justify-between overflow-hidden rounded-[26px] border border-white/10 bg-gradient-to-br from-emerald-500/30 via-emerald-500/10 to-white/5 p-6 backdrop-blur transition hover:-translate-y-1 hover:border-white/40"
+              class="group relative flex flex-col justify-between overflow-hidden rounded-[22px] border border-white/20 bg-gradient-to-br from-emerald-400/50 via-teal-400/30 to-cyan-300/30 p-6 backdrop-blur-lg transition hover:-translate-y-1 hover:shadow-[0_20px_45px_-25px_rgba(16,185,129,0.85)]"
             >
               <div class="flex items-start justify-between">
-                <span class="inline-flex h-11 w-11 items-center justify-center rounded-2xl bg-white/20 text-white/90">
+                <span class="inline-flex h-11 w-11 items-center justify-center rounded-2xl bg-white/15 text-white/95">
                   <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
                     <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M3 17l6-6 4 4 8-8" />
                   </svg>
                 </span>
-                <svg class="h-5 w-5 text-white/60 transition group-hover:translate-x-1" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                <svg class="h-5 w-5 text-white/70 transition group-hover:translate-x-1" fill="none" viewBox="0 0 24 24" stroke="currentColor">
                   <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M9 5l7 7-7 7" />
                 </svg>
               </div>
-              <h3 class="text-2xl font-medium tracking-tight">Growth</h3>
-              <p class="text-xs uppercase tracking-[0.3em] text-white/70">open</p>
+              <h3 class="text-2xl font-semibold tracking-tight">Growth</h3>
             </a>
 
             <a
               href="competitors.html"
-              class="group relative flex flex-col justify-between overflow-hidden rounded-[26px] border border-white/10 bg-gradient-to-br from-blue-500/30 via-blue-500/10 to-white/5 p-6 backdrop-blur transition hover:-translate-y-1 hover:border-white/40"
+              class="group relative flex flex-col justify-between overflow-hidden rounded-[22px] border border-white/20 bg-gradient-to-br from-sky-400/50 via-blue-400/30 to-purple-300/30 p-6 backdrop-blur-lg transition hover:-translate-y-1 hover:shadow-[0_20px_45px_-25px_rgba(56,189,248,0.8)]"
             >
               <div class="flex items-start justify-between">
-                <span class="inline-flex h-11 w-11 items-center justify-center rounded-2xl bg-white/20 text-white/90">
+                <span class="inline-flex h-11 w-11 items-center justify-center rounded-2xl bg-white/15 text-white/95">
                   <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
                     <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M12 6l8 4-8 4-8-4 8-4z" />
                     <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M4 14l8 4 8-4" />
                   </svg>
                 </span>
-                <svg class="h-5 w-5 text-white/60 transition group-hover:translate-x-1" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                <svg class="h-5 w-5 text-white/70 transition group-hover:translate-x-1" fill="none" viewBox="0 0 24 24" stroke="currentColor">
                   <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M9 5l7 7-7 7" />
                 </svg>
               </div>
-              <h3 class="text-2xl font-medium tracking-tight">Competitors</h3>
-              <p class="text-xs uppercase tracking-[0.3em] text-white/70">open</p>
+              <h3 class="text-2xl font-semibold tracking-tight">Competitors</h3>
             </a>
 
             <a
               href="inventory.html"
-              class="group relative flex flex-col justify-between overflow-hidden rounded-[26px] border border-white/10 bg-gradient-to-br from-orange-500/30 via-orange-500/10 to-white/5 p-6 backdrop-blur transition hover:-translate-y-1 hover:border-white/40"
+              class="group relative flex flex-col justify-between overflow-hidden rounded-[22px] border border-white/20 bg-gradient-to-br from-orange-400/55 via-amber-300/30 to-yellow-200/30 p-6 backdrop-blur-lg transition hover:-translate-y-1 hover:shadow-[0_20px_45px_-25px_rgba(251,191,36,0.75)]"
             >
               <div class="flex items-start justify-between">
-                <span class="inline-flex h-11 w-11 items-center justify-center rounded-2xl bg-white/20 text-white/90">
+                <span class="inline-flex h-11 w-11 items-center justify-center rounded-2xl bg-white/15 text-white/95">
                   <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
                     <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M3 7h18M3 12h18M3 17h18" />
                   </svg>
                 </span>
-                <svg class="h-5 w-5 text-white/60 transition group-hover:translate-x-1" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                <svg class="h-5 w-5 text-white/70 transition group-hover:translate-x-1" fill="none" viewBox="0 0 24 24" stroke="currentColor">
                   <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M9 5l7 7-7 7" />
                 </svg>
               </div>
-              <h3 class="text-2xl font-medium tracking-tight">Inventory</h3>
-              <p class="text-xs uppercase tracking-[0.3em] text-white/70">open</p>
+              <h3 class="text-2xl font-semibold tracking-tight">Inventory</h3>
             </a>
 
             <a
               href="finances.html"
-              class="group relative flex flex-col justify-between overflow-hidden rounded-[26px] border border-white/10 bg-gradient-to-br from-amber-500/30 via-amber-500/10 to-white/5 p-6 backdrop-blur transition hover:-translate-y-1 hover:border-white/40"
+              class="group relative flex flex-col justify-between overflow-hidden rounded-[22px] border border-white/20 bg-gradient-to-br from-amber-400/50 via-orange-300/30 to-rose-200/35 p-6 backdrop-blur-lg transition hover:-translate-y-1 hover:shadow-[0_20px_45px_-25px_rgba(251,146,60,0.8)]"
             >
               <div class="flex items-start justify-between">
-                <span class="inline-flex h-11 w-11 items-center justify-center rounded-2xl bg-white/20 text-white/90">
+                <span class="inline-flex h-11 w-11 items-center justify-center rounded-2xl bg-white/15 text-white/95">
                   <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
                     <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M12 8c-1.657 0-3 .895-3 2s1.343 2 3 2 3 .895 3 2-1.343 2-3 2m0-8c1.105 0 2 .672 2 1.5S13.105 11 12 11m0-3c-1.105 0-2-.672-2-1.5S10.895 5 12 5m0 14v-2m0-10V5" />
                   </svg>
                 </span>
-                <svg class="h-5 w-5 text-white/60 transition group-hover:translate-x-1" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                <svg class="h-5 w-5 text-white/70 transition group-hover:translate-x-1" fill="none" viewBox="0 0 24 24" stroke="currentColor">
                   <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M9 5l7 7-7 7" />
                 </svg>
               </div>
-              <h3 class="text-2xl font-medium tracking-tight">Finances</h3>
-              <p class="text-xs uppercase tracking-[0.3em] text-white/70">open</p>
+              <h3 class="text-2xl font-semibold tracking-tight">Finances</h3>
             </a>
 
             <a
               href="experiments.html"
-              class="group relative flex flex-col justify-between overflow-hidden rounded-[26px] border border-white/10 bg-gradient-to-br from-indigo-500/30 via-indigo-500/10 to-white/5 p-6 backdrop-blur transition hover:-translate-y-1 hover:border-white/40"
+              class="group relative flex flex-col justify-between overflow-hidden rounded-[22px] border border-white/20 bg-gradient-to-br from-indigo-400/55 via-violet-400/30 to-blue-300/30 p-6 backdrop-blur-lg transition hover:-translate-y-1 hover:shadow-[0_20px_45px_-25px_rgba(99,102,241,0.8)]"
             >
               <div class="flex items-start justify-between">
-                <span class="inline-flex h-11 w-11 items-center justify-center rounded-2xl bg-white/20 text-white/90">
+                <span class="inline-flex h-11 w-11 items-center justify-center rounded-2xl bg-white/15 text-white/95">
                   <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
                     <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M4.5 3.75h15m-12 0v6.878a2.25 2.25 0 01-.659 1.591l-1.885 1.885a2.25 2.25 0 001.591 3.841h10.866a2.25 2.25 0 001.591-3.841l-1.885-1.885a2.25 2.25 0 01-.659-1.591V3.75" />
                   </svg>
                 </span>
-                <svg class="h-5 w-5 text-white/60 transition group-hover:translate-x-1" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                <svg class="h-5 w-5 text-white/70 transition group-hover:translate-x-1" fill="none" viewBox="0 0 24 24" stroke="currentColor">
                   <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M9 5l7 7-7 7" />
                 </svg>
               </div>
-              <h3 class="text-2xl font-medium tracking-tight">Experiments</h3>
-              <p class="text-xs uppercase tracking-[0.3em] text-white/70">open</p>
+              <h3 class="text-2xl font-semibold tracking-tight">Experiments</h3>
             </a>
 
             <a
               href="human-advisor.html"
-              class="group relative flex flex-col justify-between overflow-hidden rounded-[26px] border border-white/10 bg-gradient-to-br from-rose-500/30 via-rose-500/10 to-white/5 p-6 backdrop-blur transition hover:-translate-y-1 hover:border-white/40"
+              class="group relative flex flex-col justify-between overflow-hidden rounded-[22px] border border-white/20 bg-gradient-to-br from-rose-500/55 via-rose-400/30 to-orange-300/30 p-6 backdrop-blur-lg transition hover:-translate-y-1 hover:shadow-[0_20px_45px_-25px_rgba(244,114,182,0.85)]"
             >
               <div class="flex items-start justify-between">
-                <span class="inline-flex h-11 w-11 items-center justify-center rounded-2xl bg-white/20 text-white/90">
+                <span class="inline-flex h-11 w-11 items-center justify-center rounded-2xl bg-white/15 text-white/95">
                   <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
                     <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M16 7a4 4 0 11-8 0 4 4 0 018 0z" />
                     <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M12 14a7 7 0 00-7 7h14a7 7 0 00-7-7z" />
                   </svg>
                 </span>
-                <svg class="h-5 w-5 text-white/60 transition group-hover:translate-x-1" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                <svg class="h-5 w-5 text-white/70 transition group-hover:translate-x-1" fill="none" viewBox="0 0 24 24" stroke="currentColor">
                   <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M9 5l7 7-7 7" />
                 </svg>
               </div>
-              <h3 class="text-2xl font-medium tracking-tight">Human Advisor</h3>
-              <p class="text-xs uppercase tracking-[0.3em] text-white/70">open</p>
+              <h3 class="text-2xl font-semibold tracking-tight">Human Advisor</h3>
+            </a>
+
+            <a
+              href="ai-companion.html"
+              class="group relative flex flex-col justify-between overflow-hidden rounded-[22px] border border-white/20 bg-gradient-to-br from-slate-100/70 via-white/40 to-blue-200/45 p-6 text-slate-900 backdrop-blur-lg transition hover:-translate-y-1 hover:shadow-[0_20px_45px_-25px_rgba(148,163,184,0.8)]"
+            >
+              <div class="flex items-start justify-between">
+                <span class="inline-flex h-11 w-11 items-center justify-center rounded-2xl bg-white/90 text-slate-900">
+                  <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.6" d="M12 6v6l3 3m6-3a9 9 0 11-18 0 9 9 0 0118 0z" />
+                  </svg>
+                </span>
+                <svg class="h-5 w-5 text-slate-700 transition group-hover:translate-x-1" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                  <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M9 5l7 7-7 7" />
+                </svg>
+              </div>
+              <h3 class="text-2xl font-semibold tracking-tight">Genie Copilot</h3>
             </a>
           </div>
         </section>
       </main>
 
-      <footer class="px-6 md:px-12 pb-10 text-xs text-white/40">
+      <footer class="px-6 md:px-12 pb-10 text-sm text-white/60">
         Built for demo purposes using fictionalized insights inspired by Golden Singha Thai Restaurant in Seattle.
       </footer>
     </div>

--- a/experiments.html
+++ b/experiments.html
@@ -9,11 +9,13 @@
         theme: {
           extend: {
             fontFamily: {
-              script: ['"Great Vibes"', 'cursive'],
-              sans: ['"Inter"', 'system-ui', 'sans-serif'],
+              script: ['"Dancing Script"', 'cursive'],
+              sans: ['"Manrope"', 'system-ui', 'sans-serif'],
             },
             colors: {
-              night: '#050505',
+              night: '#070711',
+              surface: 'rgba(19, 25, 45, 0.7)',
+              outline: 'rgba(255,255,255,0.12)',
             },
           },
         },
@@ -22,11 +24,16 @@
     <script src="https://cdn.tailwindcss.com"></script>
     <link
       rel="stylesheet"
-      href="https://fonts.googleapis.com/css2?family=Great+Vibes&family=Inter:wght@300;400;500;600;700&display=swap"
+      href="https://fonts.googleapis.com/css2?family=Dancing+Script:wght@500;600&family=Manrope:wght@400;500;600;700&display=swap"
     />
     <style>
       body {
-        background: #030303;
+        background: radial-gradient(circle at top left, rgba(129, 140, 248, 0.2), transparent 45%),
+          radial-gradient(circle at top right, rgba(244, 114, 182, 0.18), transparent 50%), #050508;
+      }
+      [contenteditable]:empty:before {
+        content: attr(data-placeholder);
+        color: rgba(255, 255, 255, 0.4);
       }
     </style>
   </head>
@@ -36,32 +43,35 @@
         <div class="space-y-4">
           <button
             onclick="window.location.href='demo.html'"
-            class="inline-flex items-center justify-center w-11 h-11 rounded-full border border-white/20 text-white hover:border-white/60 transition"
+            class="inline-flex items-center justify-center w-11 h-11 rounded-full border border-white/25 bg-white/5 text-white hover:border-white/60 transition"
             aria-label="Back to apps"
           >
             <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" class="w-5 h-5">
               <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M15 19l-7-7 7-7" />
             </svg>
           </button>
-          <div class="text-4xl font-script tracking-wide italic">genie</div>
+          <div class="text-4xl font-script leading-none text-white">genie</div>
         </div>
         <div class="text-right">
-          <p class="uppercase tracking-[0.4em] text-xs text-white/60">your AI business advisor</p>
+          <p class="text-sm text-white/70">Your AI business advisor</p>
         </div>
       </header>
 
       <main class="flex-1 py-10 flex flex-col gap-12">
         <section class="max-w-4xl">
           <h1 class="text-5xl md:text-6xl font-light">Experiments</h1>
-          <p class="mt-3 text-sm uppercase tracking-[0.5em] text-white/40">playground</p>
+          <p class="mt-3 text-base text-white/70">Vertical lab of the tests we're running right now.</p>
         </section>
 
-        <section class="rounded-[32px] border border-white/10 bg-white/5 p-8 backdrop-blur">
+        <section class="rounded-[32px] border border-outline/60 bg-surface backdrop-blur-xl p-8">
           <div class="flex flex-wrap items-center justify-between gap-4">
-            <h2 class="text-2xl font-light">Wall</h2>
+            <div>
+              <h2 class="text-2xl font-semibold">Experiment wall</h2>
+              <p class="text-sm text-white/60">Stacked by priority · drag-ready layout coming soon</p>
+            </div>
             <button
               id="addExperiment"
-              class="inline-flex items-center gap-2 rounded-full border border-white/30 px-4 py-2 text-sm font-medium text-white hover:border-white/60 transition"
+              class="inline-flex items-center gap-2 rounded-full bg-white text-black px-4 py-2 text-sm font-semibold shadow hover:bg-white/90 transition"
               type="button"
             >
               <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
@@ -70,7 +80,8 @@
               Add experiment
             </button>
           </div>
-          <div id="experiment-board" class="mt-8 grid gap-6 md:grid-cols-2"></div>
+
+          <div id="experiment-board" class="mt-10 space-y-8"></div>
         </section>
       </main>
     </div>
@@ -81,8 +92,8 @@
       role="dialog"
       aria-modal="true"
     >
-      <div class="w-full max-w-sm rounded-3xl border border-white/10 bg-white/10 p-6 backdrop-blur">
-        <h2 class="text-xl font-light">Create experiment</h2>
+      <div class="w-full max-w-md rounded-3xl border border-outline bg-surface p-6 backdrop-blur-xl">
+        <h2 class="text-xl font-semibold">Create experiment</h2>
         <label class="mt-4 block text-sm text-white/70">Title</label>
         <input
           id="experiment-title-input"
@@ -94,7 +105,7 @@
           <button id="cancel-experiment" type="button" class="rounded-full border border-white/30 px-4 py-2 text-white hover:border-white/60 transition">
             Cancel
           </button>
-          <button id="create-experiment" type="button" class="rounded-full bg-white px-4 py-2 text-black hover:bg-white/80 transition">
+          <button id="create-experiment" type="button" class="rounded-full bg-white px-4 py-2 text-black font-semibold hover:bg-white/80 transition">
             Create
           </button>
         </div>
@@ -102,35 +113,54 @@
     </div>
 
     <template id="experiment-template">
-      <div class="experiment-card rounded-[32px] border border-white/10 bg-white/5 p-6 backdrop-blur flex flex-col items-center gap-6">
-        <div
-          class="w-full rounded-3xl bg-gradient-to-r from-indigo-500/30 via-indigo-500/10 to-white/10 px-4 py-3 text-center text-lg font-light focus:outline-none"
-          contenteditable="true"
-        ></div>
-        <div class="flex w-full items-start justify-between gap-6">
-          <div class="flex-1 flex flex-col items-center gap-3">
-            <svg class="h-12 w-12 text-white/40" viewBox="0 0 48 48" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-              <path d="M24 4v28" />
-              <path d="M24 32l-6-6" />
-              <path d="M24 32l6-6" />
-            </svg>
+      <div class="experiment-card relative overflow-hidden rounded-[28px] border border-outline bg-white/5 p-7 backdrop-blur">
+        <div class="flex flex-wrap items-center justify-between gap-3">
+          <h3 class="text-xl font-semibold text-white" contenteditable="true" data-placeholder="Experiment title"></h3>
+          <span class="rounded-full bg-white/10 px-3 py-1 text-xs text-white/70">Active</span>
+        </div>
+        <div class="mt-6 grid gap-6 md:grid-cols-[minmax(0,1.2fr),auto,minmax(0,1fr)] items-start">
+          <div class="space-y-3">
+            <p class="text-sm font-semibold text-white/70">Plan</p>
             <div
-              class="w-full rounded-3xl border border-white/15 bg-white/5 px-4 py-3 text-sm text-white/80"
+              class="rounded-2xl border border-white/15 bg-night/40 px-4 py-3 text-sm text-white/80"
               contenteditable="true"
-              data-placeholder="Results"
-            >Results...</div>
+              data-placeholder="What are we testing?"
+            ></div>
           </div>
-          <div class="flex-1 flex flex-col items-center gap-3">
-            <svg class="h-12 w-12 text-white/40" viewBox="0 0 48 48" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-              <path d="M24 4v28" />
-              <path d="M24 32l-6-6" />
-              <path d="M24 32l6-6" />
+          <div class="hidden md:flex h-full items-center justify-center">
+            <svg viewBox="0 0 120 160" class="h-32 w-20 text-white/30">
+              <defs>
+                <marker id="arrowhead" markerWidth="6" markerHeight="6" refX="5" refY="3" orient="auto">
+                  <polygon points="0 0, 6 3, 0 6" fill="currentColor"></polygon>
+                </marker>
+              </defs>
+              <path
+                d="M10 10 C 100 30, 20 80, 95 110"
+                fill="none"
+                stroke="currentColor"
+                stroke-width="6"
+                stroke-linecap="round"
+                marker-end="url(#arrowhead)"
+              ></path>
             </svg>
-            <div
-              class="w-full rounded-3xl border border-white/15 bg-white/5 px-4 py-3 text-sm text-white/80"
-              contenteditable="true"
-              data-placeholder="Evidence"
-            >Evidence...</div>
+          </div>
+          <div class="space-y-5">
+            <div class="space-y-3">
+              <p class="text-sm font-semibold text-white/70">Results</p>
+              <div
+                class="rounded-2xl border border-white/15 bg-night/40 px-4 py-3 text-sm text-white/80"
+                contenteditable="true"
+                data-placeholder="What happened?"
+              ></div>
+            </div>
+            <div class="space-y-3">
+              <p class="text-sm font-semibold text-white/70">Evidence</p>
+              <div
+                class="rounded-2xl border border-white/15 bg-night/40 px-4 py-3 text-sm text-white/80"
+                contenteditable="true"
+                data-placeholder="Link metrics, screenshots, notes"
+              ></div>
+            </div>
           </div>
         </div>
       </div>
@@ -159,8 +189,14 @@
 
       function createExperimentCard(title) {
         const clone = template.content.firstElementChild.cloneNode(true);
-        const titleBox = clone.querySelector('[contenteditable="true"]');
+        const titleBox = clone.querySelector('h3[contenteditable]');
+        const planBox = clone.querySelector('[data-placeholder="What are we testing?"]');
+        const resultsBox = clone.querySelector('[data-placeholder="What happened?"]');
+        const evidenceBox = clone.querySelector('[data-placeholder="Link metrics, screenshots, notes"]');
         titleBox.textContent = title;
+        planBox.textContent = 'Outline the hypothesis, channels, and audience signal here.';
+        resultsBox.textContent = 'Waiting on initial readout.';
+        evidenceBox.textContent = 'Drop screenshots, KPI notes, or links as the test runs.';
         board.appendChild(clone);
       }
 
@@ -179,7 +215,6 @@
         }
       });
 
-      // Seed a couple of cards for context
       ['UW finals comfort tour', 'Pad thai passport'].forEach(createExperimentCard);
     </script>
   </body>

--- a/finances.html
+++ b/finances.html
@@ -9,11 +9,13 @@
         theme: {
           extend: {
             fontFamily: {
-              script: ['"Great Vibes"', 'cursive'],
-              sans: ['"Inter"', 'system-ui', 'sans-serif'],
+              script: ['"Dancing Script"', 'cursive'],
+              sans: ['"Manrope"', 'system-ui', 'sans-serif'],
             },
             colors: {
-              night: '#050505',
+              night: '#070711',
+              surface: 'rgba(24, 26, 42, 0.7)',
+              outline: 'rgba(255,255,255,0.12)',
             },
           },
         },
@@ -22,11 +24,12 @@
     <script src="https://cdn.tailwindcss.com"></script>
     <link
       rel="stylesheet"
-      href="https://fonts.googleapis.com/css2?family=Great+Vibes&family=Inter:wght@300;400;500;600;700&display=swap"
+      href="https://fonts.googleapis.com/css2?family=Dancing+Script:wght@500;600&family=Manrope:wght@400;500;600;700&display=swap"
     />
     <style>
       body {
-        background: #030303;
+        background: radial-gradient(circle at top left, rgba(251, 191, 36, 0.18), transparent 45%),
+          radial-gradient(circle at top right, rgba(249, 115, 22, 0.16), transparent 55%), #050508;
       }
     </style>
   </head>
@@ -36,150 +39,37 @@
         <div class="space-y-4">
           <button
             onclick="window.location.href='demo.html'"
-            class="inline-flex items-center justify-center w-11 h-11 rounded-full border border-white/20 text-white hover:border-white/60 transition"
+            class="inline-flex items-center justify-center w-11 h-11 rounded-full border border-white/25 bg-white/5 text-white hover:border-white/60 transition"
             aria-label="Back to apps"
           >
             <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" class="w-5 h-5">
               <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M15 19l-7-7 7-7" />
             </svg>
           </button>
-          <div class="text-4xl font-script tracking-wide italic">genie</div>
+          <div class="text-4xl font-script leading-none text-white">genie</div>
         </div>
         <div class="text-right">
-          <p class="uppercase tracking-[0.4em] text-xs text-white/60">your AI business advisor</p>
+          <p class="text-sm text-white/70">Your AI business advisor</p>
         </div>
       </header>
 
-      <main class="flex-1 py-10 flex flex-col gap-12">
-        <section class="max-w-4xl">
+      <main class="flex-1 py-10 flex flex-col gap-12 items-center justify-center text-center">
+        <div>
           <h1 class="text-5xl md:text-6xl font-light">Finances</h1>
-          <p class="mt-3 text-sm uppercase tracking-[0.5em] text-white/40">snapshot</p>
-        </section>
-
-        <section class="grid gap-6 md:grid-cols-3">
-          <div class="rounded-[28px] border border-white/10 bg-white/5 p-6 backdrop-blur flex flex-col">
-            <div class="flex items-center justify-between text-xs uppercase tracking-[0.35em] text-white/60">
-              <span>Revenue</span>
-              <span class="inline-flex h-9 w-9 items-center justify-center rounded-2xl bg-white/15 text-white/80">
-                <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                  <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M11 3v18m6-10l-6-8-6 8" />
-                </svg>
-              </span>
-            </div>
-            <div class="mt-6 text-4xl font-light">$82.4k</div>
-            <div class="mt-auto flex items-end gap-1 h-20">
-              <div class="flex-1 rounded-full bg-white/15 h-4"></div>
-              <div class="flex-1 rounded-full bg-white/15 h-8"></div>
-              <div class="flex-1 rounded-full bg-white/15 h-12"></div>
-              <div class="flex-1 rounded-full bg-white/40 h-16"></div>
-            </div>
+          <p class="mt-3 text-base text-white/70">Deeper runway and cash views are almost ready.</p>
+        </div>
+        <div class="rounded-[32px] border border-outline/60 bg-surface backdrop-blur-xl px-10 py-12 max-w-2xl space-y-6">
+          <div class="inline-flex items-center gap-2 rounded-full border border-white/25 px-4 py-1 text-sm text-white/70">
+            <span class="h-2 w-2 rounded-full bg-amber-400 animate-pulse"></span>
+            Coming soon
           </div>
-
-          <div class="rounded-[28px] border border-white/10 bg-white/5 p-6 backdrop-blur flex flex-col">
-            <div class="flex items-center justify-between text-xs uppercase tracking-[0.35em] text-white/60">
-              <span>Margin</span>
-              <span class="inline-flex h-9 w-9 items-center justify-center rounded-2xl bg-white/15 text-white/80">
-                <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                  <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M12 8c-1.657 0-3 .895-3 2s1.343 2 3 2 3 .895 3 2-1.343 2-3 2m0-8c1.105 0 2 .672 2 1.5S13.105 11 12 11m0-3c-1.105 0-2-.672-2-1.5S10.895 5 12 5m0 14v-2m0-10V5" />
-                </svg>
-              </span>
-            </div>
-            <div class="mt-6 text-4xl font-light">34%</div>
-            <div class="mt-auto grid grid-cols-2 gap-2 text-xs text-white/70">
-              <div class="rounded-2xl bg-white/10 px-3 py-2 text-center">Food 28%</div>
-              <div class="rounded-2xl bg-white/10 px-3 py-2 text-center">Labor 32%</div>
-              <div class="rounded-2xl bg-white/10 px-3 py-2 text-center">Ops 18%</div>
-              <div class="rounded-2xl bg-white/10 px-3 py-2 text-center">Marketing 10%</div>
-            </div>
+          <p class="text-lg text-white/80">
+            We're finishing the cash flow canvas, forecasting lanes, and vendor insights. Genie will notify you once the module opens.
+          </p>
+          <div class="text-sm text-white/60">
+            Need numbers sooner? Ping your advisor and we’ll drop a custom export in your inbox.
           </div>
-
-          <div class="rounded-[28px] border border-white/10 bg-white/5 p-6 backdrop-blur flex flex-col">
-            <div class="flex items-center justify-between text-xs uppercase tracking-[0.35em] text-white/60">
-              <span>Cash</span>
-              <span class="inline-flex h-9 w-9 items-center justify-center rounded-2xl bg-white/15 text-white/80">
-                <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                  <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M12 6v12m6-6H6" />
-                </svg>
-              </span>
-            </div>
-            <div class="mt-6 text-4xl font-light">$46.2k</div>
-            <div class="mt-auto space-y-2 text-xs text-white/60">
-              <div class="rounded-2xl bg-white/10 px-3 py-2">Payroll ready</div>
-              <div class="rounded-2xl bg-white/10 px-3 py-2">Night market fund</div>
-              <div class="rounded-2xl bg-white/10 px-3 py-2">Cushion 6 weeks</div>
-            </div>
-          </div>
-        </section>
-
-        <section class="grid gap-6 lg:grid-cols-[1.2fr,0.8fr]">
-          <div class="rounded-[32px] border border-white/10 bg-white/5 p-8 backdrop-blur space-y-6">
-            <div class="flex items-center justify-between">
-              <h2 class="text-2xl font-light">Forecast lanes</h2>
-              <span class="text-xs uppercase tracking-[0.4em] text-white/40">next 8w</span>
-            </div>
-            <div class="grid gap-4 sm:grid-cols-2 text-sm text-white/70">
-              <div class="rounded-3xl bg-gradient-to-br from-amber-500/30 via-amber-500/10 to-white/10 p-6">
-                <p class="text-xs uppercase tracking-[0.35em] text-white/60">Base</p>
-                <p class="mt-6 text-2xl font-light">$78k</p>
-              </div>
-              <div class="rounded-3xl bg-gradient-to-br from-emerald-500/30 via-emerald-500/10 to-white/10 p-6">
-                <p class="text-xs uppercase tracking-[0.35em] text-white/60">Stretch</p>
-                <p class="mt-6 text-2xl font-light">$92k</p>
-              </div>
-              <div class="rounded-3xl bg-gradient-to-br from-rose-500/30 via-rose-500/10 to-white/10 p-6">
-                <p class="text-xs uppercase tracking-[0.35em] text-white/60">Downside</p>
-                <p class="mt-6 text-2xl font-light">$68k</p>
-              </div>
-              <div class="rounded-3xl bg-gradient-to-br from-blue-500/30 via-blue-500/10 to-white/10 p-6">
-                <p class="text-xs uppercase tracking-[0.35em] text-white/60">Events</p>
-                <p class="mt-6 text-2xl font-light">$12k add</p>
-              </div>
-            </div>
-          </div>
-
-          <aside class="rounded-[32px] border border-white/10 bg-white/5 p-8 backdrop-blur space-y-6">
-            <h2 class="text-2xl font-light">Upcoming notes</h2>
-            <div class="space-y-4 text-sm text-white/70">
-              <div class="flex items-center justify-between">
-                <span class="rounded-full bg-white/15 px-3 py-1 text-xs uppercase tracking-[0.35em]">today</span>
-                <span class="text-white/60">Square sync</span>
-              </div>
-              <div class="flex items-center justify-between">
-                <span class="rounded-full bg-white/15 px-3 py-1 text-xs uppercase tracking-[0.35em]">+3d</span>
-                <span class="text-white/60">Payroll draft</span>
-              </div>
-              <div class="flex items-center justify-between">
-                <span class="rounded-full bg-white/15 px-3 py-1 text-xs uppercase tracking-[0.35em]">+7d</span>
-                <span class="text-white/60">Catering invoicing</span>
-              </div>
-            </div>
-          </aside>
-        </section>
-
-        <section class="rounded-[32px] border border-white/10 bg-white/5 p-8 backdrop-blur">
-          <div class="flex flex-wrap items-center justify-between gap-4">
-            <h2 class="text-2xl font-light">Runway</h2>
-            <span class="text-xs uppercase tracking-[0.4em] text-white/40">monitored</span>
-          </div>
-          <div class="mt-8 grid gap-4 md:grid-cols-4 text-sm text-white/70">
-            <div class="rounded-3xl bg-white/10 p-5 text-center">
-              <p class="text-xs uppercase tracking-[0.35em] text-white/50">Rent</p>
-              <p class="mt-5 text-2xl font-light">paid</p>
-            </div>
-            <div class="rounded-3xl bg-white/10 p-5 text-center">
-              <p class="text-xs uppercase tracking-[0.35em] text-white/50">Vendors</p>
-              <p class="mt-5 text-2xl font-light">on time</p>
-            </div>
-            <div class="rounded-3xl bg-white/10 p-5 text-center">
-              <p class="text-xs uppercase tracking-[0.35em] text-white/50">Marketing</p>
-              <p class="mt-5 text-2xl font-light">budget ok</p>
-            </div>
-            <div class="rounded-3xl bg-white/10 p-5 text-center">
-              <p class="text-xs uppercase tracking-[0.35em] text-white/50">Capex</p>
-              <p class="mt-5 text-2xl font-light">paused</p>
-            </div>
-          </div>
-        </section>
+        </div>
       </main>
     </div>
   </body>

--- a/growth.html
+++ b/growth.html
@@ -9,11 +9,13 @@
         theme: {
           extend: {
             fontFamily: {
-              script: ['"Great Vibes"', 'cursive'],
-              sans: ['"Inter"', 'system-ui', 'sans-serif'],
+              script: ['"Dancing Script"', 'cursive'],
+              sans: ['"Manrope"', 'system-ui', 'sans-serif'],
             },
             colors: {
-              night: '#050505',
+              night: '#070711',
+              surface: 'rgba(16, 24, 40, 0.65)',
+              outline: 'rgba(255,255,255,0.12)',
             },
           },
         },
@@ -22,11 +24,12 @@
     <script src="https://cdn.tailwindcss.com"></script>
     <link
       rel="stylesheet"
-      href="https://fonts.googleapis.com/css2?family=Great+Vibes&family=Inter:wght@300;400;500;600;700&display=swap"
+      href="https://fonts.googleapis.com/css2?family=Dancing+Script:wght@500;600&family=Manrope:wght@400;500;600;700&display=swap"
     />
     <style>
       body {
-        background: #030303;
+        background: radial-gradient(circle at top left, rgba(34, 211, 238, 0.16), transparent 45%),
+          radial-gradient(circle at top right, rgba(16, 185, 129, 0.18), transparent 50%), #050508;
       }
     </style>
   </head>
@@ -36,170 +39,292 @@
         <div class="space-y-4">
           <button
             onclick="window.location.href='demo.html'"
-            class="inline-flex items-center justify-center w-11 h-11 rounded-full border border-white/20 text-white hover:border-white/60 transition"
+            class="inline-flex items-center justify-center w-11 h-11 rounded-full border border-white/25 bg-white/5 text-white hover:border-white/60 transition"
             aria-label="Back to apps"
           >
             <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" class="w-5 h-5">
               <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M15 19l-7-7 7-7" />
             </svg>
           </button>
-          <div class="text-4xl font-script tracking-wide italic">genie</div>
+          <div class="text-4xl font-script leading-none text-white">genie</div>
         </div>
         <div class="text-right">
-          <p class="uppercase tracking-[0.4em] text-xs text-white/60">your AI business advisor</p>
+          <p class="text-sm text-white/70">Your AI business advisor</p>
         </div>
       </header>
 
       <main class="flex-1 py-10 flex flex-col gap-12">
         <section class="max-w-4xl">
           <h1 class="text-5xl md:text-6xl font-light">Growth</h1>
-          <p class="mt-3 text-sm uppercase tracking-[0.5em] text-white/40">momentum</p>
+          <p class="mt-3 text-base text-white/70">Momentum view of covers, delivery, and pipeline.</p>
         </section>
 
-        <section class="grid gap-6 md:grid-cols-3">
-          <div class="rounded-[28px] border border-white/10 bg-white/5 p-6 backdrop-blur flex flex-col">
-            <div class="flex items-center justify-between text-xs uppercase tracking-[0.35em] text-white/60">
-              <span>Dining</span>
-              <span class="inline-flex h-9 w-9 items-center justify-center rounded-2xl bg-white/15 text-white/80">
-                <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                  <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M3 17l6-6 4 4 8-8" />
-                </svg>
-              </span>
-            </div>
-            <div class="mt-6 text-4xl font-light">186 covers</div>
-            <div class="mt-auto flex items-end gap-1 h-20">
-              <div class="flex-1 rounded-full bg-white/15 h-4"></div>
-              <div class="flex-1 rounded-full bg-white/15 h-8"></div>
-              <div class="flex-1 rounded-full bg-white/15 h-12"></div>
-              <div class="flex-1 rounded-full bg-white/40 h-16"></div>
-            </div>
-          </div>
-
-          <div class="rounded-[28px] border border-white/10 bg-white/5 p-6 backdrop-blur flex flex-col">
-            <div class="flex items-center justify-between text-xs uppercase tracking-[0.35em] text-white/60">
-              <span>Delivery</span>
-              <span class="inline-flex h-9 w-9 items-center justify-center rounded-2xl bg-white/15 text-white/80">
-                <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                  <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M4 6h16m-7 4h7m-7 4h7m-7 4h7" />
-                </svg>
-              </span>
-            </div>
-            <div class="mt-6 text-4xl font-light">$14.8k</div>
-            <div class="mt-auto grid grid-cols-3 gap-3 text-xs text-white/70">
-              <div class="rounded-2xl bg-white/10 px-3 py-2 text-center">Dinner</div>
-              <div class="rounded-2xl bg-white/10 px-3 py-2 text-center">Late</div>
-              <div class="rounded-2xl bg-white/10 px-3 py-2 text-center">Bundles</div>
-            </div>
-          </div>
-
-          <div class="rounded-[28px] border border-white/10 bg-white/5 p-6 backdrop-blur flex flex-col">
-            <div class="flex items-center justify-between text-xs uppercase tracking-[0.35em] text-white/60">
-              <span>Pipeline</span>
-              <span class="inline-flex h-9 w-9 items-center justify-center rounded-2xl bg-white/15 text-white/80">
-                <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                  <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M4 12h16m-8-8v16" />
-                </svg>
-              </span>
-            </div>
-            <div class="mt-6 text-4xl font-light">7 leads</div>
-            <div class="mt-auto space-y-2 text-xs text-white/60">
-              <div class="flex items-center justify-between">
-                <span class="rounded-full bg-white/10 px-3 py-1">Catering</span>
-                <span class="text-white/40">43% win</span>
-              </div>
-              <div class="flex items-center justify-between">
-                <span class="rounded-full bg-white/10 px-3 py-1">Events</span>
-                <span class="text-white/40">3 booked</span>
-              </div>
-            </div>
-          </div>
-        </section>
-
-        <section class="grid gap-6 lg:grid-cols-[1.1fr,0.9fr]">
-          <div class="rounded-[32px] border border-white/10 bg-white/5 p-8 backdrop-blur space-y-6">
-            <div class="flex items-center justify-between">
-              <h2 class="text-2xl font-light">Plays in motion</h2>
-              <span class="text-xs uppercase tracking-[0.4em] text-white/40">now</span>
-            </div>
-            <div class="grid gap-4 md:grid-cols-2">
-              <div class="rounded-3xl bg-gradient-to-br from-emerald-500/30 via-emerald-500/10 to-white/10 p-5">
-                <p class="text-sm uppercase tracking-[0.35em] text-white/60">this week</p>
-                <p class="mt-5 text-xl font-light">Chef counter livestream</p>
-              </div>
-              <div class="rounded-3xl bg-gradient-to-br from-sky-500/30 via-sky-500/10 to-white/10 p-5">
-                <p class="text-sm uppercase tracking-[0.35em] text-white/60">next</p>
-                <p class="mt-5 text-xl font-light">UW finals comfort tour</p>
-              </div>
-              <div class="rounded-3xl bg-gradient-to-br from-amber-500/30 via-amber-500/10 to-white/10 p-5">
-                <p class="text-sm uppercase tracking-[0.35em] text-white/60">later</p>
-                <p class="mt-5 text-xl font-light">Night market pop-up</p>
-              </div>
-              <div class="rounded-3xl bg-gradient-to-br from-rose-500/30 via-rose-500/10 to-white/10 p-5">
-                <p class="text-sm uppercase tracking-[0.35em] text-white/60">watch</p>
-                <p class="mt-5 text-xl font-light">Capitol hill takeover</p>
-              </div>
-            </div>
-          </div>
-
-          <aside class="rounded-[32px] border border-white/10 bg-white/5 p-8 backdrop-blur space-y-6">
-            <h2 class="text-2xl font-light">Flow lane</h2>
-            <div class="space-y-5 text-sm text-white/70">
-              <div class="flex items-center gap-3">
-                <span class="h-10 w-10 rounded-full bg-white/10 flex items-center justify-center">A</span>
-                <div>
-                  <p class="text-white/80">Awareness</p>
-                  <div class="mt-2 h-1.5 w-32 rounded-full bg-white/20">
-                    <div class="h-full w-3/4 rounded-full bg-white/60"></div>
-                  </div>
-                </div>
-              </div>
-              <div class="flex items-center gap-3">
-                <span class="h-10 w-10 rounded-full bg-white/10 flex items-center justify-center">B</span>
-                <div>
-                  <p class="text-white/80">Booking</p>
-                  <div class="mt-2 h-1.5 w-32 rounded-full bg-white/20">
-                    <div class="h-full w-2/3 rounded-full bg-white/60"></div>
-                  </div>
-                </div>
-              </div>
-              <div class="flex items-center gap-3">
-                <span class="h-10 w-10 rounded-full bg-white/10 flex items-center justify-center">R</span>
-                <div>
-                  <p class="text-white/80">Repeat</p>
-                  <div class="mt-2 h-1.5 w-32 rounded-full bg-white/20">
-                    <div class="h-full w-4/5 rounded-full bg-white/60"></div>
-                  </div>
-                </div>
-              </div>
-            </div>
-          </aside>
-        </section>
-
-        <section class="rounded-[32px] border border-white/10 bg-white/5 p-8 backdrop-blur">
+        <section class="rounded-[32px] border border-outline/60 bg-surface backdrop-blur-xl p-8 space-y-8">
           <div class="flex flex-wrap items-center justify-between gap-4">
-            <h2 class="text-2xl font-light">Signal tiles</h2>
-            <span class="text-xs uppercase tracking-[0.4em] text-white/40">snapshots</span>
+            <div class="inline-flex rounded-full bg-white/10 p-1 text-sm">
+              <button class="tab-trigger rounded-full px-4 py-2 font-medium bg-white text-black" data-target="growth-strategy">
+                Strategy
+              </button>
+              <button class="tab-trigger rounded-full px-4 py-2 font-medium text-white/70 hover:text-white transition" data-target="growth-stats">
+                Stats
+              </button>
+            </div>
+            <span class="text-sm text-white/60">Updated · moments ago</span>
           </div>
-          <div class="mt-8 grid gap-4 md:grid-cols-4 text-sm text-white/70">
-            <div class="rounded-3xl bg-white/10 p-5">
-              <p class="text-xs uppercase tracking-[0.35em] text-white/50">traffic</p>
-              <p class="mt-5 text-2xl font-light">+12%</p>
+
+          <div id="growth-strategy" class="tab-panel space-y-8">
+            <div class="relative rounded-[28px] border border-outline bg-white/5 p-8">
+              <div class="flex items-start justify-between gap-6">
+                <div>
+                  <h2 class="text-2xl font-semibold">MECE pipeline map</h2>
+                  <p class="mt-2 text-white/70 max-w-xl">
+                    Breaking growth into acquisition, conversion, retention, and expansion lets us spot gaps instantly. Genie keeps these lanes balanced with the latest signals.
+                  </p>
+                </div>
+                <div class="relative">
+                  <button
+                    id="growth-ai-button"
+                    class="inline-flex items-center gap-2 rounded-full bg-rose-500 px-4 py-2 text-sm font-semibold shadow-lg hover:bg-rose-400 transition"
+                    type="button"
+                  >
+                    <span class="inline-block h-2 w-2 rounded-full bg-white animate-pulse"></span>
+                    AI suggestion
+                  </button>
+                  <div
+                    id="growth-ai-menu"
+                    class="absolute right-0 mt-3 hidden w-48 rounded-2xl border border-white/20 bg-night/95 p-3 text-sm shadow-2xl"
+                  >
+                    <button class="menu-option flex w-full items-center gap-2 rounded-xl px-3 py-2 text-left text-white/80 hover:bg-white/10" data-action="change">
+                      <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.6" d="M4 7h16M4 12h12m-6 5h6" />
+                      </svg>
+                      Change plan
+                    </button>
+                    <button class="menu-option flex w-full items-center gap-2 rounded-xl px-3 py-2 text-left text-white/80 hover:bg-white/10" data-action="experiment">
+                      <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.6" d="M12 6v12m6-6H6" />
+                      </svg>
+                      Add to experiment
+                    </button>
+                  </div>
+                </div>
+              </div>
+
+              <div class="mt-8 grid gap-6 md:grid-cols-2 xl:grid-cols-4">
+                <div class="rounded-3xl bg-gradient-to-br from-emerald-400/35 via-emerald-400/15 to-transparent p-6">
+                  <p class="text-sm font-semibold text-white/80">Acquisition</p>
+                  <ul class="mt-4 space-y-3 text-sm text-white/70">
+                    <li>Chef counter livestream draws 180 viewers</li>
+                    <li>DoorDash bundles promoted after 8pm</li>
+                    <li>Campus flyering with QR codes</li>
+                  </ul>
+                </div>
+                <div class="rounded-3xl bg-gradient-to-br from-cyan-400/35 via-cyan-400/15 to-transparent p-6">
+                  <p class="text-sm font-semibold text-white/80">Conversion</p>
+                  <ul class="mt-4 space-y-3 text-sm text-white/70">
+                    <li>Two-tap waitlist with upsell suggestions</li>
+                    <li>Tablets stationed at grab-and-go queue</li>
+                    <li>Chef stories displayed on in-store screens</li>
+                  </ul>
+                </div>
+                <div class="rounded-3xl bg-gradient-to-br from-violet-400/35 via-violet-400/15 to-transparent p-6">
+                  <p class="text-sm font-semibold text-white/80">Retention</p>
+                  <ul class="mt-4 space-y-3 text-sm text-white/70">
+                    <li>Loyalty SMS prompts 72-hour return visit</li>
+                    <li>Personalized "family meal" follow-ups</li>
+                    <li>Chef Bee check-in DM every Friday</li>
+                  </ul>
+                </div>
+                <div class="rounded-3xl bg-gradient-to-br from-amber-400/35 via-amber-400/15 to-transparent p-6">
+                  <p class="text-sm font-semibold text-white/80">Expansion</p>
+                  <ul class="mt-4 space-y-3 text-sm text-white/70">
+                    <li>Catering sampler runs to downtown offices</li>
+                    <li>Night market pop-up with merch booth</li>
+                    <li>Partnership pipeline with UW clubs</li>
+                  </ul>
+                </div>
+              </div>
             </div>
-            <div class="rounded-3xl bg-white/10 p-5">
-              <p class="text-xs uppercase tracking-[0.35em] text-white/50">covers</p>
-              <p class="mt-5 text-2xl font-light">164 forecast</p>
+
+            <div class="grid gap-6 lg:grid-cols-[1.1fr,0.9fr]">
+              <div class="rounded-[28px] border border-outline bg-white/5 p-7 space-y-6">
+                <div class="flex items-center justify-between">
+                  <h3 class="text-xl font-semibold">Plays in motion</h3>
+                  <span class="text-sm text-white/60">Live + scheduled</span>
+                </div>
+                <div class="grid gap-4 sm:grid-cols-2 text-sm text-white/80">
+                  <div class="rounded-2xl bg-gradient-to-br from-emerald-400/30 via-emerald-400/10 to-transparent p-5">
+                    <p class="text-xs uppercase tracking-wide text-white/60">This week</p>
+                    <p class="mt-3 text-lg font-semibold">Chef counter livestream</p>
+                    <p class="mt-2 text-white/60">Target: 25 bookings</p>
+                  </div>
+                  <div class="rounded-2xl bg-gradient-to-br from-cyan-400/30 via-cyan-400/10 to-transparent p-5">
+                    <p class="text-xs uppercase tracking-wide text-white/60">Next</p>
+                    <p class="mt-3 text-lg font-semibold">UW finals comfort tour</p>
+                    <p class="mt-2 text-white/60">Covers goal: 320</p>
+                  </div>
+                  <div class="rounded-2xl bg-gradient-to-br from-violet-400/30 via-violet-400/10 to-transparent p-5">
+                    <p class="text-xs uppercase tracking-wide text-white/60">Testing</p>
+                    <p class="mt-3 text-lg font-semibold">Night market pre-orders</p>
+                    <p class="mt-2 text-white/60">40 orders to greenlight</p>
+                  </div>
+                  <div class="rounded-2xl bg-gradient-to-br from-amber-400/30 via-amber-400/10 to-transparent p-5">
+                    <p class="text-xs uppercase tracking-wide text-white/60">Pipeline</p>
+                    <p class="mt-3 text-lg font-semibold">Tech catering pilots</p>
+                    <p class="mt-2 text-white/60">3 proposals pending</p>
+                  </div>
+                </div>
+              </div>
+
+              <aside class="rounded-[28px] border border-outline bg-white/5 p-7 space-y-5">
+                <div class="flex items-center justify-between">
+                  <h3 class="text-xl font-semibold">Growth notes</h3>
+                  <span class="inline-flex items-center gap-2 rounded-full border border-white/25 px-3 py-1 text-xs text-white/70">
+                    <span class="h-2 w-2 rounded-full bg-emerald-400"></span>
+                    Synced
+                  </span>
+                </div>
+                <ul class="space-y-3 text-sm text-white/75">
+                  <li class="flex items-start gap-3">
+                    <span class="mt-1 h-2.5 w-2.5 rounded-full bg-emerald-400"></span>
+                    Add SMS bounceback for guests who order delivery twice in a week.
+                  </li>
+                  <li class="flex items-start gap-3">
+                    <span class="mt-1 h-2.5 w-2.5 rounded-full bg-cyan-400"></span>
+                    Model 24-hour prep plan for finals late-night service.
+                  </li>
+                  <li class="flex items-start gap-3">
+                    <span class="mt-1 h-2.5 w-2.5 rounded-full bg-violet-400"></span>
+                    Stand up referral tracker for student organizations.
+                  </li>
+                </ul>
+              </aside>
             </div>
-            <div class="rounded-3xl bg-white/10 p-5">
-              <p class="text-xs uppercase tracking-[0.35em] text-white/50">loyalty</p>
-              <p class="mt-5 text-2xl font-light">28% reorder</p>
+          </div>
+
+          <div id="growth-stats" class="tab-panel hidden space-y-8">
+            <div class="grid gap-6 md:grid-cols-4 text-center">
+              <div class="rounded-3xl border border-outline bg-white/5 p-6">
+                <p class="text-sm text-white/60">Dining covers</p>
+                <p class="mt-3 text-3xl font-semibold">186</p>
+                <p class="mt-2 text-sm text-emerald-300">+12 vs last week</p>
+              </div>
+              <div class="rounded-3xl border border-outline bg-white/5 p-6">
+                <p class="text-sm text-white/60">Delivery rev</p>
+                <p class="mt-3 text-3xl font-semibold">$14.8k</p>
+                <p class="mt-2 text-sm text-emerald-300">+9% trailing 7d</p>
+              </div>
+              <div class="rounded-3xl border border-outline bg-white/5 p-6">
+                <p class="text-sm text-white/60">Pipeline deals</p>
+                <p class="mt-3 text-3xl font-semibold">7</p>
+                <p class="mt-2 text-sm text-emerald-300">3 near close</p>
+              </div>
+              <div class="rounded-3xl border border-outline bg-white/5 p-6">
+                <p class="text-sm text-white/60">Repeat rate</p>
+                <p class="mt-3 text-3xl font-semibold">28%</p>
+                <p class="mt-2 text-sm text-emerald-300">+4 pts MOM</p>
+              </div>
             </div>
-            <div class="rounded-3xl bg-white/10 p-5">
-              <p class="text-xs uppercase tracking-[0.35em] text-white/50">reviews</p>
-              <p class="mt-5 text-2xl font-light">4.6 ★</p>
+
+            <div class="grid gap-6 lg:grid-cols-[1.1fr,0.9fr]">
+              <div class="rounded-[28px] border border-outline bg-white/5 p-7">
+                <h3 class="text-xl font-semibold">Flow lane</h3>
+                <div class="mt-6 space-y-5 text-sm text-white/75">
+                  <div class="flex items-center justify-between">
+                    <div>
+                      <p class="font-semibold text-white/80">Awareness</p>
+                      <p class="text-xs text-white/60">Paid + organic blend</p>
+                    </div>
+                    <div class="h-2 w-28 rounded-full bg-white/15">
+                      <div class="h-2 rounded-full bg-emerald-300" style="width: 76%"></div>
+                    </div>
+                  </div>
+                  <div class="flex items-center justify-between">
+                    <div>
+                      <p class="font-semibold text-white/80">Booking</p>
+                      <p class="text-xs text-white/60">Reservations + walk-ins</p>
+                    </div>
+                    <div class="h-2 w-28 rounded-full bg-white/15">
+                      <div class="h-2 rounded-full bg-emerald-300" style="width: 62%"></div>
+                    </div>
+                  </div>
+                  <div class="flex items-center justify-between">
+                    <div>
+                      <p class="font-semibold text-white/80">Repeat</p>
+                      <p class="text-xs text-white/60">Loyalty + SMS</p>
+                    </div>
+                    <div class="h-2 w-28 rounded-full bg-white/15">
+                      <div class="h-2 rounded-full bg-emerald-300" style="width: 81%"></div>
+                    </div>
+                  </div>
+                </div>
+              </div>
+
+              <aside class="rounded-[28px] border border-outline bg-white/5 p-7 space-y-6">
+                <h3 class="text-xl font-semibold">Signals</h3>
+                <ul class="space-y-4 text-sm text-white/75">
+                  <li class="flex items-center justify-between">
+                    <span>Late night wait time</span>
+                    <span class="rounded-full bg-white/10 px-3 py-1 text-xs">7 min</span>
+                  </li>
+                  <li class="flex items-center justify-between">
+                    <span>Average check size</span>
+                    <span class="rounded-full bg-white/10 px-3 py-1 text-xs">$27.40</span>
+                  </li>
+                  <li class="flex items-center justify-between">
+                    <span>Delivery bundles sold</span>
+                    <span class="rounded-full bg-white/10 px-3 py-1 text-xs">64</span>
+                  </li>
+                  <li class="flex items-center justify-between">
+                    <span>Events pipeline</span>
+                    <span class="rounded-full bg-white/10 px-3 py-1 text-xs">5 warm</span>
+                  </li>
+                </ul>
+              </aside>
             </div>
           </div>
         </section>
       </main>
     </div>
+
+    <script>
+      const tabButtons = document.querySelectorAll('.tab-trigger');
+      const panels = document.querySelectorAll('.tab-panel');
+      tabButtons.forEach((button) => {
+        button.addEventListener('click', () => {
+          tabButtons.forEach((btn) => btn.classList.remove('bg-white', 'text-black', 'text-white/70'));
+          button.classList.add('bg-white', 'text-black');
+          tabButtons.forEach((btn) => btn !== button && btn.classList.add('text-white/70'));
+          panels.forEach((panel) => {
+            if (panel.id === button.dataset.target) {
+              panel.classList.remove('hidden');
+            } else {
+              panel.classList.add('hidden');
+            }
+          });
+        });
+      });
+
+      const aiButton = document.getElementById('growth-ai-button');
+      const aiMenu = document.getElementById('growth-ai-menu');
+      aiButton?.addEventListener('click', (event) => {
+        event.stopPropagation();
+        aiMenu.classList.toggle('hidden');
+      });
+      document.addEventListener('click', (event) => {
+        if (!aiMenu.contains(event.target) && !aiButton.contains(event.target)) {
+          aiMenu.classList.add('hidden');
+        }
+      });
+
+      const growthOptions = document.querySelectorAll('#growth-ai-menu .menu-option');
+      growthOptions.forEach((option) => {
+        option.addEventListener('click', () => {
+          aiMenu.classList.add('hidden');
+          const action = option.dataset.action;
+          alert(action === 'change' ? 'Genie is tuning the growth plan.' : 'Experiment card drafted in Experiments.');
+        });
+      });
+    </script>
   </body>
 </html>

--- a/human-advisor.html
+++ b/human-advisor.html
@@ -9,11 +9,13 @@
         theme: {
           extend: {
             fontFamily: {
-              script: ['"Great Vibes"', 'cursive'],
-              sans: ['"Inter"', 'system-ui', 'sans-serif'],
+              script: ['"Dancing Script"', 'cursive'],
+              sans: ['"Manrope"', 'system-ui', 'sans-serif'],
             },
             colors: {
-              night: '#050505',
+              night: '#070711',
+              surface: 'rgba(22, 24, 40, 0.7)',
+              outline: 'rgba(255,255,255,0.12)',
             },
           },
         },
@@ -22,11 +24,12 @@
     <script src="https://cdn.tailwindcss.com"></script>
     <link
       rel="stylesheet"
-      href="https://fonts.googleapis.com/css2?family=Great+Vibes&family=Inter:wght@300;400;500;600;700&display=swap"
+      href="https://fonts.googleapis.com/css2?family=Dancing+Script:wght@500;600&family=Manrope:wght@400;500;600;700&display=swap"
     />
     <style>
       body {
-        background: #030303;
+        background: radial-gradient(circle at top left, rgba(244, 114, 182, 0.18), transparent 45%),
+          radial-gradient(circle at top right, rgba(251, 191, 36, 0.16), transparent 55%), #050508;
       }
     </style>
   </head>
@@ -36,95 +39,130 @@
         <div class="space-y-4">
           <button
             onclick="window.location.href='demo.html'"
-            class="inline-flex items-center justify-center w-11 h-11 rounded-full border border-white/20 text-white hover:border-white/60 transition"
+            class="inline-flex items-center justify-center w-11 h-11 rounded-full border border-white/25 bg-white/5 text-white hover:border-white/60 transition"
             aria-label="Back to apps"
           >
             <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" class="w-5 h-5">
               <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M15 19l-7-7 7-7" />
             </svg>
           </button>
-          <div class="text-4xl font-script tracking-wide italic">genie</div>
+          <div class="text-4xl font-script leading-none text-white">genie</div>
         </div>
         <div class="text-right">
-          <p class="uppercase tracking-[0.4em] text-xs text-white/60">your AI business advisor</p>
+          <p class="text-sm text-white/70">Your AI business advisor</p>
         </div>
       </header>
 
       <main class="flex-1 py-10 flex flex-col gap-12">
         <section class="max-w-4xl">
           <h1 class="text-5xl md:text-6xl font-light">Human Advisor</h1>
-          <p class="mt-3 text-sm uppercase tracking-[0.5em] text-white/40">concierge</p>
+          <p class="mt-3 text-base text-white/70">Direct line to your dedicated operator — chat or hop on a call.</p>
         </section>
 
-        <section class="grid gap-6 lg:grid-cols-[1.2fr,0.8fr]">
-          <div class="rounded-[32px] border border-white/10 bg-white/5 p-8 backdrop-blur space-y-8">
-            <div class="flex items-center justify-between">
-              <h2 class="text-2xl font-light">Team</h2>
-              <span class="text-xs uppercase tracking-[0.4em] text-white/40">available</span>
-            </div>
-            <div class="grid gap-4 sm:grid-cols-2 text-sm text-white/70">
-              <div class="rounded-3xl bg-gradient-to-br from-rose-500/30 via-rose-500/10 to-white/10 p-6">
-                <p class="text-xs uppercase tracking-[0.35em] text-white/60">Mila</p>
-                <p class="mt-5 text-xl font-light">Growth partner</p>
-                <p class="mt-3 text-white/50">Next check-in 2pm</p>
+        <section class="rounded-[32px] border border-outline/60 bg-surface backdrop-blur-xl p-8">
+          <div class="grid gap-6 lg:grid-cols-[0.95fr,1.05fr]">
+            <aside class="rounded-[28px] border border-outline bg-white/5 p-6 space-y-6">
+              <div>
+                <h2 class="text-xl font-semibold">Your advisor</h2>
+                <p class="mt-2 text-sm text-white/70">Mila Ortiz · Growth partner</p>
               </div>
-              <div class="rounded-3xl bg-gradient-to-br from-sky-500/30 via-sky-500/10 to-white/10 p-6">
-                <p class="text-xs uppercase tracking-[0.35em] text-white/60">Noon</p>
-                <p class="mt-5 text-xl font-light">Operations</p>
-                <p class="mt-3 text-white/50">Shift sync 4pm</p>
+              <div class="space-y-4 text-sm text-white/80">
+                <div class="rounded-2xl bg-white/5 p-4">
+                  <p class="text-xs text-white/60">Mobile</p>
+                  <p class="mt-1 text-white">(206) 555-0128</p>
+                </div>
+                <div class="rounded-2xl bg-white/5 p-4">
+                  <p class="text-xs text-white/60">Email</p>
+                  <p class="mt-1 text-white">mila@suitandthai.ai</p>
+                </div>
+                <div class="rounded-2xl bg-white/5 p-4">
+                  <p class="text-xs text-white/60">Office hours</p>
+                  <p class="mt-1 text-white">Mon–Fri · 9a – 5p PT</p>
+                </div>
               </div>
-              <div class="rounded-3xl bg-gradient-to-br from-emerald-500/30 via-emerald-500/10 to-white/10 p-6">
-                <p class="text-xs uppercase tracking-[0.35em] text-white/60">Lena</p>
-                <p class="mt-5 text-xl font-light">Finance</p>
-                <p class="mt-3 text-white/50">Report drop Friday</p>
+              <div class="space-y-3 text-sm text-white/75">
+                <h3 class="text-sm font-semibold text-white/80">Upcoming</h3>
+                <div class="rounded-2xl border border-white/10 bg-white/5 p-4">
+                  <p class="text-white/80">Night Market budget review</p>
+                  <p class="text-xs text-white/50 mt-1">Today · 3:30p PT · 30 min</p>
+                </div>
+                <div class="rounded-2xl border border-white/10 bg-white/5 p-4">
+                  <p class="text-white/80">Influencer dinner recap</p>
+                  <p class="text-xs text-white/50 mt-1">Thu · 11:00a PT · 20 min</p>
+                </div>
               </div>
-              <div class="rounded-3xl bg-gradient-to-br from-purple-500/30 via-purple-500/10 to-white/10 p-6">
-                <p class="text-xs uppercase tracking-[0.35em] text-white/60">Kai</p>
-                <p class="mt-5 text-xl font-light">Experiments</p>
-                <p class="mt-3 text-white/50">Wall update 1pm</p>
+              <div class="space-y-3">
+                <h3 class="text-sm font-semibold text-white/80">Quick actions</h3>
+                <div class="grid grid-cols-2 gap-3 text-sm">
+                  <button class="rounded-2xl bg-white text-black py-2 font-semibold hover:bg-white/90 transition">Start chat</button>
+                  <button class="rounded-2xl border border-white/30 py-2 font-semibold text-white hover:border-white/60 transition">Start video call</button>
+                  <button class="col-span-2 rounded-2xl border border-white/20 py-2 font-semibold text-white/80 hover:border-white/60 transition">Send files</button>
+                </div>
               </div>
-            </div>
-          </div>
+            </aside>
 
-          <aside class="rounded-[32px] border border-white/10 bg-white/5 p-8 backdrop-blur space-y-6">
-            <h2 class="text-2xl font-light">Contact</h2>
-            <div class="space-y-4 text-sm text-white/70">
-              <div class="rounded-3xl bg-white/10 p-4">
-                <p class="text-xs uppercase tracking-[0.35em] text-white/50">Text</p>
-                <p class="mt-2 text-white/80">(206) 555-0128</p>
+            <div class="rounded-[28px] border border-outline bg-white/5 p-6 flex flex-col">
+              <div class="flex flex-wrap items-center justify-between gap-3 border-b border-white/10 pb-4">
+                <div>
+                  <h2 class="text-xl font-semibold">Session board</h2>
+                  <p class="text-sm text-white/60">Catch up or drop a note before the call.</p>
+                </div>
+                <div class="inline-flex items-center gap-2 rounded-full border border-white/25 px-3 py-1 text-xs text-white/70">
+                  <span class="h-2 w-2 rounded-full bg-emerald-400"></span>
+                  Mila is online
+                </div>
               </div>
-              <div class="rounded-3xl bg-white/10 p-4">
-                <p class="text-xs uppercase tracking-[0.35em] text-white/50">Email</p>
-                <p class="mt-2 text-white/80">hello@suitandtie.ai</p>
-              </div>
-              <div class="rounded-3xl bg-white/10 p-4">
-                <p class="text-xs uppercase tracking-[0.35em] text-white/50">Office</p>
-                <p class="mt-2 text-white/80">Remote · Seattle + SF</p>
-              </div>
-            </div>
-          </aside>
-        </section>
 
-        <section class="rounded-[32px] border border-white/10 bg-white/5 p-8 backdrop-blur">
-          <div class="flex flex-wrap items-center justify-between gap-4">
-            <h2 class="text-2xl font-light">Call board</h2>
-            <span class="text-xs uppercase tracking-[0.4em] text-white/40">queue</span>
-          </div>
-          <div class="mt-8 grid gap-4 md:grid-cols-3 text-sm text-white/70">
-            <div class="rounded-3xl bg-white/10 p-5">
-              <p class="text-xs uppercase tracking-[0.35em] text-white/50">Next</p>
-              <p class="mt-5 text-xl font-light">Night market budget</p>
-              <p class="mt-3 text-white/50">10:30am · Lena</p>
-            </div>
-            <div class="rounded-3xl bg-white/10 p-5">
-              <p class="text-xs uppercase tracking-[0.35em] text-white/50">Later</p>
-              <p class="mt-5 text-xl font-light">Influencer dinner recap</p>
-              <p class="mt-3 text-white/50">1:00pm · Mila</p>
-            </div>
-            <div class="rounded-3xl bg-white/10 p-5">
-              <p class="text-xs uppercase tracking-[0.35em] text-white/50">Queued</p>
-              <p class="mt-5 text-xl font-light">POS integration</p>
-              <p class="mt-3 text-white/50">4:30pm · Kai</p>
+              <div class="flex-1 overflow-y-auto py-6 space-y-5 text-sm text-white/80">
+                <div class="space-y-2">
+                  <p class="text-xs text-white/50">Yesterday · 4:12p</p>
+                  <div class="max-w-xl rounded-2xl bg-white/10 px-4 py-3">
+                    Looking over Night Market staffing. Anything you want me to prep before tomorrow?
+                  </div>
+                </div>
+                <div class="space-y-2 text-right">
+                  <p class="text-xs text-white/50">You · 4:18p</p>
+                  <div class="ml-auto max-w-xl rounded-2xl bg-gradient-to-r from-rose-500/50 via-rose-500/20 to-white/10 px-4 py-3 text-left">
+                    Could you stress test the 10pm rush forecast and flag if we need a third POS?
+                  </div>
+                </div>
+                <div class="space-y-2">
+                  <p class="text-xs text-white/50">Today · 9:07a</p>
+                  <div class="max-w-xl rounded-2xl bg-white/10 px-4 py-3">
+                    Running numbers now — expect a note in the doc by noon. Want to add a 15-min sync?
+                  </div>
+                </div>
+              </div>
+
+              <form class="border-t border-white/10 pt-4 space-y-3" onsubmit="event.preventDefault();">
+                <textarea
+                  rows="3"
+                  class="w-full rounded-2xl border border-white/20 bg-transparent p-4 text-sm text-white placeholder:text-white/40 focus:border-white focus:outline-none"
+                  placeholder="Update Mila before the next call…"
+                ></textarea>
+                <div class="flex flex-wrap items-center justify-between gap-3 text-sm">
+                  <div class="flex items-center gap-2 text-white/60">
+                    <button type="button" class="inline-flex items-center gap-2 rounded-full border border-white/25 px-3 py-1 hover:border-white/60 transition">
+                      <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M15.232 5.232l3.536 3.536M9 13l6 6M4 7l5 5" />
+                      </svg>
+                      Attach
+                    </button>
+                    <button type="button" class="inline-flex items-center gap-2 rounded-full border border-white/25 px-3 py-1 hover:border-white/60 transition">
+                      <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M12 6v6l3 3" />
+                      </svg>
+                      Schedule
+                    </button>
+                  </div>
+                  <button type="submit" class="inline-flex items-center gap-2 rounded-full bg-white text-black px-5 py-2 font-semibold hover:bg-white/90 transition">
+                    Send update
+                    <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M5 12h14M12 5l7 7-7 7" />
+                    </svg>
+                  </button>
+                </div>
+              </form>
             </div>
           </div>
         </section>

--- a/inventory.html
+++ b/inventory.html
@@ -9,11 +9,13 @@
         theme: {
           extend: {
             fontFamily: {
-              script: ['"Great Vibes"', 'cursive'],
-              sans: ['"Inter"', 'system-ui', 'sans-serif'],
+              script: ['"Dancing Script"', 'cursive'],
+              sans: ['"Manrope"', 'system-ui', 'sans-serif'],
             },
             colors: {
-              night: '#050505',
+              night: '#070711',
+              surface: 'rgba(24, 24, 38, 0.7)',
+              outline: 'rgba(255,255,255,0.12)',
             },
           },
         },
@@ -22,11 +24,12 @@
     <script src="https://cdn.tailwindcss.com"></script>
     <link
       rel="stylesheet"
-      href="https://fonts.googleapis.com/css2?family=Great+Vibes&family=Inter:wght@300;400;500;600;700&display=swap"
+      href="https://fonts.googleapis.com/css2?family=Dancing+Script:wght@500;600&family=Manrope:wght@400;500;600;700&display=swap"
     />
     <style>
       body {
-        background: #030303;
+        background: radial-gradient(circle at top left, rgba(249, 168, 37, 0.16), transparent 45%),
+          radial-gradient(circle at top right, rgba(34, 197, 94, 0.16), transparent 55%), #050508;
       }
     </style>
   </head>
@@ -36,149 +39,37 @@
         <div class="space-y-4">
           <button
             onclick="window.location.href='demo.html'"
-            class="inline-flex items-center justify-center w-11 h-11 rounded-full border border-white/20 text-white hover:border-white/60 transition"
+            class="inline-flex items-center justify-center w-11 h-11 rounded-full border border-white/25 bg-white/5 text-white hover:border-white/60 transition"
             aria-label="Back to apps"
           >
             <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" class="w-5 h-5">
               <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M15 19l-7-7 7-7" />
             </svg>
           </button>
-          <div class="text-4xl font-script tracking-wide italic">genie</div>
+          <div class="text-4xl font-script leading-none text-white">genie</div>
         </div>
         <div class="text-right">
-          <p class="uppercase tracking-[0.4em] text-xs text-white/60">your AI business advisor</p>
+          <p class="text-sm text-white/70">Your AI business advisor</p>
         </div>
       </header>
 
-      <main class="flex-1 py-10 flex flex-col gap-12">
-        <section class="max-w-4xl">
+      <main class="flex-1 py-10 flex flex-col gap-12 items-center justify-center text-center">
+        <div>
           <h1 class="text-5xl md:text-6xl font-light">Inventory</h1>
-          <p class="mt-3 text-sm uppercase tracking-[0.5em] text-white/40">back-of-house</p>
-        </section>
-
-        <section class="grid gap-6 md:grid-cols-3">
-          <div class="rounded-[28px] border border-white/10 bg-white/5 p-6 backdrop-blur flex flex-col">
-            <div class="flex items-center justify-between text-xs uppercase tracking-[0.35em] text-white/60">
-              <span>Pantry</span>
-              <span class="inline-flex h-9 w-9 items-center justify-center rounded-2xl bg-white/15 text-white/80">
-                <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                  <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M3 7h18M3 12h18M3 17h18" />
-                </svg>
-              </span>
-            </div>
-            <div class="mt-6 text-4xl font-light">82%</div>
-            <div class="mt-auto grid grid-cols-2 gap-2 text-xs text-white/70">
-              <div class="rounded-2xl bg-white/10 px-3 py-2 text-center">Noodles</div>
-              <div class="rounded-2xl bg-white/10 px-3 py-2 text-center">Sauces</div>
-              <div class="rounded-2xl bg-white/10 px-3 py-2 text-center">Spices</div>
-              <div class="rounded-2xl bg-white/10 px-3 py-2 text-center">Rice</div>
-            </div>
+          <p class="mt-3 text-base text-white/70">Back-of-house control is on the way.</p>
+        </div>
+        <div class="rounded-[32px] border border-outline/60 bg-surface backdrop-blur-xl px-10 py-12 max-w-2xl space-y-6">
+          <div class="inline-flex items-center gap-2 rounded-full border border-white/25 px-4 py-1 text-sm text-white/70">
+            <span class="h-2 w-2 rounded-full bg-emerald-400 animate-pulse"></span>
+            Coming soon
           </div>
-
-          <div class="rounded-[28px] border border-white/10 bg-white/5 p-6 backdrop-blur flex flex-col">
-            <div class="flex items-center justify-between text-xs uppercase tracking-[0.35em] text-white/60">
-              <span>Prep</span>
-              <span class="inline-flex h-9 w-9 items-center justify-center rounded-2xl bg-white/15 text-white/80">
-                <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                  <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M12 6v12m6-6H6" />
-                </svg>
-              </span>
-            </div>
-            <div class="mt-6 text-4xl font-light">5 kits</div>
-            <div class="mt-auto flex items-end gap-2 h-16">
-              <div class="flex-1 rounded-full bg-white/15 h-6"></div>
-              <div class="flex-1 rounded-full bg-white/15 h-10"></div>
-              <div class="flex-1 rounded-full bg-white/40 h-14"></div>
-            </div>
+          <p class="text-lg text-white/80">
+            Genie is building real-time prep levels, vendor alerts, and forecasted depletion for Suit and Thai. You'll see it here first.
+          </p>
+          <div class="text-sm text-white/60">
+            Want early access? Let us know and we’ll invite you to the pilot rollout.
           </div>
-
-          <div class="rounded-[28px] border border-white/10 bg-white/5 p-6 backdrop-blur flex flex-col">
-            <div class="flex items-center justify-between text-xs uppercase tracking-[0.35em] text-white/60">
-              <span>Alerts</span>
-              <span class="inline-flex h-9 w-9 items-center justify-center rounded-2xl bg-white/15 text-white/80">
-                <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                  <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M12 9v2m0 4h.01M12 19a7 7 0 100-14 7 7 0 000 14z" />
-                </svg>
-              </span>
-            </div>
-            <div class="mt-6 text-4xl font-light">3 flags</div>
-            <div class="mt-auto space-y-2 text-xs text-white/60">
-              <div class="rounded-2xl bg-white/10 px-3 py-2">Thai basil low</div>
-              <div class="rounded-2xl bg-white/10 px-3 py-2">Coconut milk reorder</div>
-              <div class="rounded-2xl bg-white/10 px-3 py-2">To-go cups rush</div>
-            </div>
-          </div>
-        </section>
-
-        <section class="grid gap-6 lg:grid-cols-[1.2fr,0.8fr]">
-          <div class="rounded-[32px] border border-white/10 bg-white/5 p-8 backdrop-blur space-y-6">
-            <div class="flex items-center justify-between">
-              <h2 class="text-2xl font-light">Walk-in map</h2>
-              <span class="text-xs uppercase tracking-[0.4em] text-white/40">live temp</span>
-            </div>
-            <div class="grid gap-4 sm:grid-cols-2">
-              <div class="rounded-3xl bg-gradient-to-br from-orange-500/30 via-orange-500/10 to-white/10 p-6 text-sm text-white/70">
-                <p class="text-xs uppercase tracking-[0.35em] text-white/60">Protein</p>
-                <p class="mt-6 text-2xl font-light">36°F</p>
-              </div>
-              <div class="rounded-3xl bg-gradient-to-br from-emerald-500/30 via-emerald-500/10 to-white/10 p-6 text-sm text-white/70">
-                <p class="text-xs uppercase tracking-[0.35em] text-white/60">Veg</p>
-                <p class="mt-6 text-2xl font-light">39°F</p>
-              </div>
-              <div class="rounded-3xl bg-gradient-to-br from-sky-500/30 via-sky-500/10 to-white/10 p-6 text-sm text-white/70">
-                <p class="text-xs uppercase tracking-[0.35em] text-white/60">Prep</p>
-                <p class="mt-6 text-2xl font-light">34°F</p>
-              </div>
-              <div class="rounded-3xl bg-gradient-to-br from-fuchsia-500/30 via-fuchsia-500/10 to-white/10 p-6 text-sm text-white/70">
-                <p class="text-xs uppercase tracking-[0.35em] text-white/60">Dessert</p>
-                <p class="mt-6 text-2xl font-light">37°F</p>
-              </div>
-            </div>
-          </div>
-
-          <aside class="rounded-[32px] border border-white/10 bg-white/5 p-8 backdrop-blur space-y-6">
-            <h2 class="text-2xl font-light">Next deliveries</h2>
-            <div class="space-y-4 text-sm text-white/70">
-              <div class="flex items-center justify-between">
-                <span class="rounded-full bg-white/15 px-3 py-1 text-xs uppercase tracking-[0.35em]">today</span>
-                <span class="text-white/60">H Mart essentials</span>
-              </div>
-              <div class="flex items-center justify-between">
-                <span class="rounded-full bg-white/15 px-3 py-1 text-xs uppercase tracking-[0.35em]">+1d</span>
-                <span class="text-white/60">Produce express</span>
-              </div>
-              <div class="flex items-center justify-between">
-                <span class="rounded-full bg-white/15 px-3 py-1 text-xs uppercase tracking-[0.35em]">+3d</span>
-                <span class="text-white/60">Seafood run</span>
-              </div>
-            </div>
-          </aside>
-        </section>
-
-        <section class="rounded-[32px] border border-white/10 bg-white/5 p-8 backdrop-blur">
-          <div class="flex flex-wrap items-center justify-between gap-4">
-            <h2 class="text-2xl font-light">Par guide</h2>
-            <span class="text-xs uppercase tracking-[0.4em] text-white/40">auto sync</span>
-          </div>
-          <div class="mt-8 grid gap-4 md:grid-cols-4 text-sm text-white/70">
-            <div class="rounded-3xl bg-white/10 p-5 text-center">
-              <p class="text-xs uppercase tracking-[0.35em] text-white/50">Pad Thai</p>
-              <p class="mt-5 text-2xl font-light">x 4 trays</p>
-            </div>
-            <div class="rounded-3xl bg-white/10 p-5 text-center">
-              <p class="text-xs uppercase tracking-[0.35em] text-white/50">Curries</p>
-              <p class="mt-5 text-2xl font-light">x 6 pans</p>
-            </div>
-            <div class="rounded-3xl bg-white/10 p-5 text-center">
-              <p class="text-xs uppercase tracking-[0.35em] text-white/50">Soup</p>
-              <p class="mt-5 text-2xl font-light">x 3 pots</p>
-            </div>
-            <div class="rounded-3xl bg-white/10 p-5 text-center">
-              <p class="text-xs uppercase tracking-[0.35em] text-white/50">Dessert</p>
-              <p class="mt-5 text-2xl font-light">x 2 trays</p>
-            </div>
-          </div>
-        </section>
+        </div>
       </main>
     </div>
   </body>

--- a/marketing.html
+++ b/marketing.html
@@ -9,11 +9,13 @@
         theme: {
           extend: {
             fontFamily: {
-              script: ['"Great Vibes"', 'cursive'],
-              sans: ['"Inter"', 'system-ui', 'sans-serif'],
+              script: ['"Dancing Script"', 'cursive'],
+              sans: ['"Manrope"', 'system-ui', 'sans-serif'],
             },
             colors: {
-              night: '#050505',
+              night: '#070711',
+              surface: 'rgba(18, 21, 36, 0.65)',
+              outline: 'rgba(255,255,255,0.12)',
             },
           },
         },
@@ -22,11 +24,12 @@
     <script src="https://cdn.tailwindcss.com"></script>
     <link
       rel="stylesheet"
-      href="https://fonts.googleapis.com/css2?family=Great+Vibes&family=Inter:wght@300;400;500;600;700&display=swap"
+      href="https://fonts.googleapis.com/css2?family=Dancing+Script:wght@500;600&family=Manrope:wght@400;500;600;700&display=swap"
     />
     <style>
       body {
-        background: #030303;
+        background: radial-gradient(circle at top left, rgba(244, 114, 182, 0.18), transparent 45%),
+          radial-gradient(circle at top right, rgba(56, 189, 248, 0.14), transparent 50%), #050508;
       }
     </style>
   </head>
@@ -36,164 +39,286 @@
         <div class="space-y-4">
           <button
             onclick="window.location.href='demo.html'"
-            class="inline-flex items-center justify-center w-11 h-11 rounded-full border border-white/20 text-white hover:border-white/60 transition"
+            class="inline-flex items-center justify-center w-11 h-11 rounded-full border border-white/25 bg-white/5 text-white hover:border-white/60 transition"
             aria-label="Back to apps"
           >
             <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" class="w-5 h-5">
               <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M15 19l-7-7 7-7" />
             </svg>
           </button>
-          <div class="text-4xl font-script tracking-wide italic">genie</div>
+          <div class="text-4xl font-script leading-none text-white">genie</div>
         </div>
         <div class="text-right">
-          <p class="uppercase tracking-[0.4em] text-xs text-white/60">your AI business advisor</p>
+          <p class="text-sm text-white/70">Your AI business advisor</p>
         </div>
       </header>
 
       <main class="flex-1 py-10 flex flex-col gap-12">
         <section class="max-w-4xl">
           <h1 class="text-5xl md:text-6xl font-light">Marketing</h1>
-          <p class="mt-3 text-sm uppercase tracking-[0.5em] text-white/40">signal board</p>
+          <p class="mt-3 text-base text-white/70">Strategy cockpit for Suit and Thai.</p>
         </section>
 
-        <section class="grid gap-6 md:grid-cols-3">
-          <div class="rounded-[28px] border border-white/10 bg-white/5 p-6 backdrop-blur flex flex-col">
-            <div class="flex items-center justify-between text-xs uppercase tracking-[0.35em] text-white/60">
-              <span>Reach</span>
-              <span class="inline-flex h-9 w-9 items-center justify-center rounded-2xl bg-white/15 text-white/80">
-                <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                  <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M4 16l4-4 4 4 6-6" />
-                </svg>
-              </span>
-            </div>
-            <div class="mt-6 text-4xl font-light">+18%</div>
-            <div class="mt-auto flex h-20 items-end gap-1 text-white/40">
-              <div class="flex-1 rounded-full bg-white/15 h-6"></div>
-              <div class="flex-1 rounded-full bg-white/15 h-10"></div>
-              <div class="flex-1 rounded-full bg-white/15 h-14"></div>
-              <div class="flex-1 rounded-full bg-white/40 h-16"></div>
-            </div>
-          </div>
-
-          <div class="rounded-[28px] border border-white/10 bg-white/5 p-6 backdrop-blur flex flex-col">
-            <div class="flex items-center justify-between text-xs uppercase tracking-[0.35em] text-white/60">
-              <span>Stories</span>
-              <span class="inline-flex h-9 w-9 items-center justify-center rounded-2xl bg-white/15 text-white/80">
-                <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                  <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M12 6v12m6-6H6" />
-                </svg>
-              </span>
-            </div>
-            <div class="mt-6 text-4xl font-light">4 queued</div>
-            <div class="mt-auto grid grid-cols-2 gap-2 text-xs text-white/70">
-              <div class="rounded-2xl bg-white/10 px-3 py-2 text-center">UW Finals</div>
-              <div class="rounded-2xl bg-white/10 px-3 py-2 text-center">Night Market</div>
-              <div class="rounded-2xl bg-white/10 px-3 py-2 text-center">Matcha Drop</div>
-              <div class="rounded-2xl bg-white/10 px-3 py-2 text-center">Chef Lens</div>
-            </div>
-          </div>
-
-          <div class="rounded-[28px] border border-white/10 bg-white/5 p-6 backdrop-blur flex flex-col">
-            <div class="flex items-center justify-between text-xs uppercase tracking-[0.35em] text-white/60">
-              <span>Spend</span>
-              <span class="inline-flex h-9 w-9 items-center justify-center rounded-2xl bg-white/15 text-white/80">
-                <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                  <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M12 8c-1.657 0-3 .895-3 2s1.343 2 3 2 3 .895 3 2-1.343 2-3 2m0-8c1.105 0 2 .672 2 1.5S13.105 11 12 11m0-3c-1.105 0-2-.672-2-1.5S10.895 5 12 5m0 14v-2m0-10V5" />
-                </svg>
-              </span>
-            </div>
-            <div class="mt-6 text-4xl font-light">$620</div>
-            <div class="mt-auto flex justify-between text-xs text-white/60">
-              <div class="flex flex-col items-center gap-2">
-                <span class="inline-flex h-10 w-10 items-center justify-center rounded-full bg-white/10 text-white/80">IG</span>
-                <span>40%</span>
-              </div>
-              <div class="flex flex-col items-center gap-2">
-                <span class="inline-flex h-10 w-10 items-center justify-center rounded-full bg-white/10 text-white/80">Ads</span>
-                <span>35%</span>
-              </div>
-              <div class="flex flex-col items-center gap-2">
-                <span class="inline-flex h-10 w-10 items-center justify-center rounded-full bg-white/10 text-white/80">PR</span>
-                <span>25%</span>
-              </div>
-            </div>
-          </div>
-        </section>
-
-        <section class="grid gap-6 lg:grid-cols-[1.2fr,0.8fr]">
-          <div class="rounded-[32px] border border-white/10 bg-white/5 p-8 backdrop-blur space-y-6">
-            <div class="flex items-center justify-between">
-              <h2 class="text-2xl font-light">Story Stack</h2>
-              <span class="text-xs uppercase tracking-[0.4em] text-white/40">swipe ready</span>
-            </div>
-            <div class="grid gap-4 sm:grid-cols-2">
-              <div class="rounded-3xl bg-gradient-to-br from-fuchsia-500/30 via-fuchsia-500/10 to-white/10 p-5">
-                <p class="text-sm uppercase tracking-[0.35em] text-white/60">reel</p>
-                <p class="mt-6 text-xl font-light">UW Finals comfort tour</p>
-              </div>
-              <div class="rounded-3xl bg-gradient-to-br from-blue-500/30 via-blue-500/10 to-white/10 p-5">
-                <p class="text-sm uppercase tracking-[0.35em] text-white/60">carousel</p>
-                <p class="mt-6 text-xl font-light">Pad thai passport</p>
-              </div>
-              <div class="rounded-3xl bg-gradient-to-br from-emerald-500/30 via-emerald-500/10 to-white/10 p-5">
-                <p class="text-sm uppercase tracking-[0.35em] text-white/60">email</p>
-                <p class="mt-6 text-xl font-light">Neighborhood night market</p>
-              </div>
-              <div class="rounded-3xl bg-gradient-to-br from-amber-500/30 via-amber-500/10 to-white/10 p-5">
-                <p class="text-sm uppercase tracking-[0.35em] text-white/60">press</p>
-                <p class="mt-6 text-xl font-light">Chef noon spotlight</p>
-              </div>
-            </div>
-          </div>
-
-          <aside class="rounded-[32px] border border-white/10 bg-white/5 p-8 backdrop-blur space-y-6">
-            <h2 class="text-2xl font-light">Beat Map</h2>
-            <div class="space-y-4 text-sm text-white/70">
-              <div class="flex items-center justify-between">
-                <span class="rounded-full bg-white/15 px-3 py-1 text-xs uppercase tracking-[0.35em]">today</span>
-                <span class="text-white/60">Chef live Q&amp;A</span>
-              </div>
-              <div class="flex items-center justify-between">
-                <span class="rounded-full bg-white/15 px-3 py-1 text-xs uppercase tracking-[0.35em]">+2d</span>
-                <span class="text-white/60">Finals care kits</span>
-              </div>
-              <div class="flex items-center justify-between">
-                <span class="rounded-full bg-white/15 px-3 py-1 text-xs uppercase tracking-[0.35em]">+5d</span>
-                <span class="text-white/60">Influencer tasting</span>
-              </div>
-              <div class="flex items-center justify-between">
-                <span class="rounded-full bg-white/15 px-3 py-1 text-xs uppercase tracking-[0.35em]">+8d</span>
-                <span class="text-white/60">Email drop</span>
-              </div>
-            </div>
-          </aside>
-        </section>
-
-        <section class="rounded-[32px] border border-white/10 bg-white/5 p-8 backdrop-blur">
+        <section class="rounded-[32px] border border-outline/60 bg-surface backdrop-blur-xl p-8 space-y-8">
           <div class="flex flex-wrap items-center justify-between gap-4">
-            <h2 class="text-2xl font-light">Channel Pulse</h2>
-            <span class="text-xs uppercase tracking-[0.4em] text-white/40">auto refresh</span>
+            <div class="inline-flex rounded-full bg-white/10 p-1 text-sm">
+              <button class="tab-trigger rounded-full px-4 py-2 font-medium bg-white text-black" data-target="marketing-strategy">
+                Strategy
+              </button>
+              <button class="tab-trigger rounded-full px-4 py-2 font-medium text-white/70 hover:text-white transition" data-target="marketing-stats">
+                Stats
+              </button>
+            </div>
+            <span class="text-sm text-white/60">Last refreshed · 3 minutes ago</span>
           </div>
-          <div class="mt-8 grid gap-6 md:grid-cols-4 text-center text-sm text-white/70">
-            <div class="space-y-4">
-              <div class="mx-auto h-20 w-20 rounded-full border border-white/20 bg-white/10 flex items-center justify-center text-3xl font-light">2.4k</div>
-              <p>IG follows</p>
+
+          <div id="marketing-strategy" class="tab-panel space-y-8">
+            <div class="relative rounded-[28px] border border-outline bg-white/5 p-8">
+              <div class="flex items-start justify-between gap-6">
+                <div>
+                  <h2 class="text-2xl font-semibold">MECE growth stack</h2>
+                  <p class="mt-2 text-white/70 max-w-xl">
+                    A one-page breakdown of every lever we are pulling across awareness, experience, community, and revenue. Each lane is mutually exclusive and collectively exhaustive so nothing slips.
+                  </p>
+                </div>
+                <div class="relative">
+                  <button
+                    id="marketing-ai-button"
+                    class="inline-flex items-center gap-2 rounded-full bg-rose-500 px-4 py-2 text-sm font-semibold shadow-lg hover:bg-rose-400 transition"
+                    type="button"
+                  >
+                    <span class="inline-block h-2 w-2 rounded-full bg-white animate-pulse"></span>
+                    AI suggestion
+                  </button>
+                  <div
+                    id="marketing-ai-menu"
+                    class="absolute right-0 mt-3 hidden w-48 rounded-2xl border border-white/20 bg-night/95 p-3 text-sm shadow-2xl"
+                  >
+                    <button class="menu-option flex w-full items-center gap-2 rounded-xl px-3 py-2 text-left text-white/80 hover:bg-white/10" data-action="change">
+                      <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.6" d="M4 7h16M4 12h16M4 17h10" />
+                      </svg>
+                      Change strategy
+                    </button>
+                    <button class="menu-option flex w-full items-center gap-2 rounded-xl px-3 py-2 text-left text-white/80 hover:bg-white/10" data-action="experiment">
+                      <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.6" d="M12 6v12m6-6H6" />
+                      </svg>
+                      Add to experiment
+                    </button>
+                  </div>
+                </div>
+              </div>
+
+              <div class="mt-8 grid gap-6 md:grid-cols-2 xl:grid-cols-4">
+                <div class="rounded-3xl bg-gradient-to-br from-pink-500/35 via-pink-500/15 to-transparent p-6">
+                  <p class="text-sm font-semibold text-white/80">Awareness</p>
+                  <ul class="mt-4 space-y-3 text-sm text-white/70">
+                    <li>UW finals comfort tour reel cadence</li>
+                    <li>Paid TikTok lead-in to Chef Bee stories</li>
+                    <li>Local press seeding via Night Market angle</li>
+                  </ul>
+                </div>
+                <div class="rounded-3xl bg-gradient-to-br from-indigo-500/35 via-indigo-500/15 to-transparent p-6">
+                  <p class="text-sm font-semibold text-white/80">Experience</p>
+                  <ul class="mt-4 space-y-3 text-sm text-white/70">
+                    <li>Host-led queue moments with instant QR order</li>
+                    <li>Prep "comfort kits" for take-home sharing</li>
+                    <li>Chef counter livestream twice a week</li>
+                  </ul>
+                </div>
+                <div class="rounded-3xl bg-gradient-to-br from-emerald-500/35 via-emerald-500/15 to-transparent p-6">
+                  <p class="text-sm font-semibold text-white/80">Community</p>
+                  <ul class="mt-4 space-y-3 text-sm text-white/70">
+                    <li>Discord check-ins with top 30 superfans</li>
+                    <li>Weekly text polls with instant appetizer codes</li>
+                    <li>Student ambassador table takeover nights</li>
+                  </ul>
+                </div>
+                <div class="rounded-3xl bg-gradient-to-br from-amber-400/40 via-amber-400/15 to-transparent p-6">
+                  <p class="text-sm font-semibold text-white/80">Revenue</p>
+                  <ul class="mt-4 space-y-3 text-sm text-white/70">
+                    <li>Bundles with Thai iced tea upsell play</li>
+                    <li>Square loyalty push for late-night crowd</li>
+                    <li>Catering sampler drops to tech offices</li>
+                  </ul>
+                </div>
+              </div>
             </div>
-            <div class="space-y-4">
-              <div class="mx-auto h-20 w-20 rounded-full border border-white/20 bg-white/10 flex items-center justify-center text-3xl font-light">11.8%</div>
-              <p>Email CTR</p>
+
+            <div class="grid gap-6 lg:grid-cols-[1.1fr,0.9fr]">
+              <div class="rounded-[28px] border border-outline bg-white/5 p-7 space-y-6">
+                <div class="flex items-center justify-between">
+                  <h3 class="text-xl font-semibold">Current storylines</h3>
+                  <span class="text-sm text-white/60">Auto-tracked</span>
+                </div>
+                <div class="grid gap-4 sm:grid-cols-2 text-sm text-white/80">
+                  <div class="rounded-2xl bg-gradient-to-br from-fuchsia-500/25 via-fuchsia-500/10 to-transparent p-5">
+                    <p class="text-xs uppercase tracking-wide text-white/60">Now live</p>
+                    <p class="mt-3 text-lg font-semibold">Chef Bee midnight radio</p>
+                    <p class="mt-2 text-white/60">Organic reach +24% vs last week.</p>
+                  </div>
+                  <div class="rounded-2xl bg-gradient-to-br from-sky-400/30 via-sky-400/10 to-transparent p-5">
+                    <p class="text-xs uppercase tracking-wide text-white/60">Next</p>
+                    <p class="mt-3 text-lg font-semibold">Night Market comfort kits</p>
+                    <p class="mt-2 text-white/60">Influencer RSVPs: 11 confirmed.</p>
+                  </div>
+                  <div class="rounded-2xl bg-gradient-to-br from-emerald-400/30 via-emerald-400/10 to-transparent p-5">
+                    <p class="text-xs uppercase tracking-wide text-white/60">Testing</p>
+                    <p class="mt-3 text-lg font-semibold">TikTok duet challenge</p>
+                    <p class="mt-2 text-white/60">Goal: +15% student traffic.</p>
+                  </div>
+                  <div class="rounded-2xl bg-gradient-to-br from-amber-400/30 via-amber-400/10 to-transparent p-5">
+                    <p class="text-xs uppercase tracking-wide text-white/60">Warm up</p>
+                    <p class="mt-3 text-lg font-semibold">Chef table email series</p>
+                    <p class="mt-2 text-white/60">Segment: top 200 SMS members.</p>
+                  </div>
+                </div>
+              </div>
+
+              <aside class="rounded-[28px] border border-outline bg-white/5 p-7 space-y-5">
+                <div class="flex items-center justify-between">
+                  <h3 class="text-xl font-semibold">Playbook notes</h3>
+                  <span class="inline-flex items-center gap-2 rounded-full border border-white/25 px-3 py-1 text-xs text-white/70">
+                    <span class="h-2 w-2 rounded-full bg-emerald-400"></span>
+                    Synced
+                  </span>
+                </div>
+                <ul class="space-y-3 text-sm text-white/75">
+                  <li class="flex items-start gap-3">
+                    <span class="mt-1 h-2.5 w-2.5 rounded-full bg-fuchsia-400"></span>
+                    Shift two budget points from static IG posts to Spark ads for TikTok challenge kickoff.
+                  </li>
+                  <li class="flex items-start gap-3">
+                    <span class="mt-1 h-2.5 w-2.5 rounded-full bg-sky-400"></span>
+                    Prep Canva templates for finals-themed Stories; assign to Mila by Thursday.
+                  </li>
+                  <li class="flex items-start gap-3">
+                    <span class="mt-1 h-2.5 w-2.5 rounded-full bg-amber-400"></span>
+                    Bundle UGC from ambassadors into a 30-second "why we study here" montage.
+                  </li>
+                </ul>
+              </aside>
             </div>
-            <div class="space-y-4">
-              <div class="mx-auto h-20 w-20 rounded-full border border-white/20 bg-white/10 flex items-center justify-center text-3xl font-light">28</div>
-              <p>Reviews</p>
+          </div>
+
+          <div id="marketing-stats" class="tab-panel hidden space-y-8">
+            <div class="grid gap-6 md:grid-cols-4 text-center">
+              <div class="rounded-3xl border border-outline bg-white/5 p-6">
+                <p class="text-sm text-white/60">Followers</p>
+                <p class="mt-3 text-3xl font-semibold">2.4k</p>
+                <p class="mt-2 text-sm text-emerald-300">+18% in 14 days</p>
+              </div>
+              <div class="rounded-3xl border border-outline bg-white/5 p-6">
+                <p class="text-sm text-white/60">Email CTR</p>
+                <p class="mt-3 text-3xl font-semibold">11.8%</p>
+                <p class="mt-2 text-sm text-emerald-300">+2.1 pts</p>
+              </div>
+              <div class="rounded-3xl border border-outline bg-white/5 p-6">
+                <p class="text-sm text-white/60">Reviews</p>
+                <p class="mt-3 text-3xl font-semibold">4.7 ★</p>
+                <p class="mt-2 text-sm text-emerald-300">41 new this month</p>
+              </div>
+              <div class="rounded-3xl border border-outline bg-white/5 p-6">
+                <p class="text-sm text-white/60">ROI</p>
+                <p class="mt-3 text-3xl font-semibold">4.2×</p>
+                <p class="mt-2 text-sm text-emerald-300">Spend $620</p>
+              </div>
             </div>
-            <div class="space-y-4">
-              <div class="mx-auto h-20 w-20 rounded-full border border-white/20 bg-white/10 flex items-center justify-center text-3xl font-light">4.2×</div>
-              <p>ROI</p>
+
+            <div class="grid gap-6 lg:grid-cols-[1.1fr,0.9fr]">
+              <div class="rounded-[28px] border border-outline bg-white/5 p-7">
+                <h3 class="text-xl font-semibold">Channel pulse</h3>
+                <div class="mt-6 grid gap-4 sm:grid-cols-2 text-sm text-white/75">
+                  <div class="rounded-2xl bg-white/5 p-5">
+                    <p class="text-sm font-semibold text-white/80">Instagram</p>
+                    <p class="mt-2 text-2xl font-semibold">+26%</p>
+                    <p class="mt-1 text-xs text-white/60">Reels saves vs baseline</p>
+                  </div>
+                  <div class="rounded-2xl bg-white/5 p-5">
+                    <p class="text-sm font-semibold text-white/80">Email</p>
+                    <p class="mt-2 text-2xl font-semibold">31%</p>
+                    <p class="mt-1 text-xs text-white/60">Active open rate</p>
+                  </div>
+                  <div class="rounded-2xl bg-white/5 p-5">
+                    <p class="text-sm font-semibold text-white/80">Google reviews</p>
+                    <p class="mt-2 text-2xl font-semibold">+17</p>
+                    <p class="mt-1 text-xs text-white/60">Mentions of "friendly"</p>
+                  </div>
+                  <div class="rounded-2xl bg-white/5 p-5">
+                    <p class="text-sm font-semibold text-white/80">Influencer buzz</p>
+                    <p class="mt-2 text-2xl font-semibold">8</p>
+                    <p class="mt-1 text-xs text-white/60">Live partnerships</p>
+                  </div>
+                </div>
+              </div>
+
+              <aside class="rounded-[28px] border border-outline bg-white/5 p-7 space-y-6">
+                <h3 class="text-xl font-semibold">Week-at-a-glance</h3>
+                <ul class="space-y-4 text-sm text-white/75">
+                  <li class="flex items-center justify-between">
+                    <span>Mon · Finals comfort drop</span>
+                    <span class="rounded-full bg-white/10 px-3 py-1 text-xs">Stories</span>
+                  </li>
+                  <li class="flex items-center justify-between">
+                    <span>Tue · TikTok duet launch</span>
+                    <span class="rounded-full bg-white/10 px-3 py-1 text-xs">Organic</span>
+                  </li>
+                  <li class="flex items-center justify-between">
+                    <span>Thu · Night Market teaser</span>
+                    <span class="rounded-full bg-white/10 px-3 py-1 text-xs">Press</span>
+                  </li>
+                  <li class="flex items-center justify-between">
+                    <span>Sat · Chef livestream</span>
+                    <span class="rounded-full bg-white/10 px-3 py-1 text-xs">Live</span>
+                  </li>
+                </ul>
+              </aside>
             </div>
           </div>
         </section>
       </main>
     </div>
+
+    <script>
+      const tabButtons = document.querySelectorAll('.tab-trigger');
+      const panels = document.querySelectorAll('.tab-panel');
+      tabButtons.forEach((button) => {
+        button.addEventListener('click', () => {
+          tabButtons.forEach((btn) => btn.classList.remove('bg-white', 'text-black', 'text-white/70'));
+          button.classList.add('bg-white', 'text-black');
+          tabButtons
+            .forEach((btn) => btn !== button && btn.classList.add('text-white/70'));
+          panels.forEach((panel) => {
+            if (panel.id === button.dataset.target) {
+              panel.classList.remove('hidden');
+            } else {
+              panel.classList.add('hidden');
+            }
+          });
+        });
+      });
+
+      const aiButton = document.getElementById('marketing-ai-button');
+      const aiMenu = document.getElementById('marketing-ai-menu');
+      aiButton?.addEventListener('click', (event) => {
+        event.stopPropagation();
+        aiMenu.classList.toggle('hidden');
+      });
+      document.addEventListener('click', (event) => {
+        if (!aiMenu.contains(event.target) && !aiButton.contains(event.target)) {
+          aiMenu.classList.add('hidden');
+        }
+      });
+
+      const menuOptions = document.querySelectorAll('#marketing-ai-menu .menu-option');
+      menuOptions.forEach((option) => {
+        option.addEventListener('click', () => {
+          aiMenu.classList.add('hidden');
+          const action = option.dataset.action;
+          alert(action === 'change' ? 'Genie queued a new strategy draft.' : 'Genie added this to Experiments.');
+        });
+      });
+    </script>
   </body>
 </html>


### PR DESCRIPTION
## Summary
- Refresh the demo hub with new type, a static home icon, brighter gradients, and a dedicated Genie Copilot entry point.
- Rebuild the Marketing and Growth apps around MECE strategy boards, AI suggestion menus, and switchable stats tabs.
- Reimagine Competitors, Experiments, Human Advisor, Finances, and Inventory views with updated layouts, vertical experiment stacking, coming-soon messaging, and a chat-ready advisor surface, plus ship the new Copilot chat experience.

## Testing
- Not run (static site)


------
https://chatgpt.com/codex/tasks/task_e_68d176148a98832f866e07a8e1ae0d72