### PR TITLE
Refresh Genie demo styling and app experiences

### DIFF
--- a/ai-companion.html
+++ b/ai-companion.html
@@ -9,13 +9,11 @@
         theme: {
           extend: {
             fontFamily: {
-              script: ['"Dancing Script"', 'cursive'],
+              script: ['"Pacifico"', '"Allura"', 'cursive'],
               sans: ['"Manrope"', 'system-ui', 'sans-serif'],
             },
             colors: {
-              night: '#f5f6fb',
-              ink: '#0f172a',
-              bubble: '#1e293b',
+              night: '#070711',
             },
           },
         },
@@ -24,16 +22,22 @@
     <script src="https://cdn.tailwindcss.com"></script>
     <link
       rel="stylesheet"
-      href="https://fonts.googleapis.com/css2?family=Dancing+Script:wght@500;600&family=Manrope:wght@400;500;600;700&display=swap"
+      href="https://fonts.googleapis.com/css2?family=Allura&family=Manrope:wght@400;500;600;700&family=Pacifico&display=swap"
     />
+    <style>
+      body {
+        background: radial-gradient(circle at top left, rgba(125, 211, 252, 0.18), transparent 45%),
+          radial-gradient(circle at top right, rgba(129, 140, 248, 0.16), transparent 50%), #050508;
+      }
+    </style>
   </head>
-  <body class="min-h-screen bg-night text-ink font-sans">
+  <body class="min-h-screen bg-night text-white font-sans">
     <div class="min-h-screen flex flex-col">
-      <header class="px-6 md:px-12 pt-8 pb-6 flex items-center justify-between">
+      <header class="px-6 md:px-12 pt-10 flex items-start justify-between">
         <div class="flex items-center gap-4">
           <button
             onclick="window.location.href='demo.html'"
-            class="inline-flex items-center justify-center w-11 h-11 rounded-full border border-ink/10 text-ink hover:bg-ink/10 transition"
+            class="inline-flex items-center justify-center w-11 h-11 rounded-full border border-white/25 bg-white/5 text-white hover:border-white/60 transition"
             aria-label="Back to apps"
           >
             <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" class="w-5 h-5">
@@ -41,95 +45,133 @@
             </svg>
           </button>
           <div>
-            <div class="text-4xl font-script leading-none text-ink">genie</div>
-            <p class="text-sm text-ink/60">Copilot assistant</p>
+            <div class="text-4xl font-script leading-none text-white tracking-wide">genie</div>
+            <p class="text-sm text-white/65">Copilot chat</p>
           </div>
         </div>
-        <div class="text-right text-sm text-ink/60">Suit and Thai · Always-on</div>
+        <div class="text-right text-sm text-white/60">Suit and Thai · Always on</div>
       </header>
 
-      <main class="flex-1 px-6 md:px-12 pb-6">
-        <div class="mx-auto max-w-4xl h-full flex flex-col rounded-3xl border border-ink/10 bg-white shadow-xl">
-          <div class="px-6 md:px-10 py-6 border-b border-ink/10 flex items-center justify-between">
+      <main class="flex-1 px-6 md:px-12 pb-10">
+        <section class="grid gap-8 lg:grid-cols-[0.45fr,1.55fr]">
+          <aside class="rounded-3xl bg-white/10 p-6 backdrop-blur-sm space-y-5 shadow-[0_20px_45px_-30px_rgba(56,189,248,0.55)] ring-1 ring-white/10">
             <div>
-              <h1 class="text-2xl font-semibold">Ask Genie anything</h1>
-              <p class="text-sm text-ink/60">Insights grounded in your marketing, growth, and sentiment data.</p>
+              <h2 class="text-xl font-semibold">Live context</h2>
+              <p class="mt-2 text-sm text-white/70">Genie is using marketing, growth, and sentiment data synced hourly.</p>
             </div>
-            <div class="inline-flex items-center gap-2 rounded-full border border-ink/10 px-3 py-1 text-xs text-ink/60">
-              <span class="h-2 w-2 rounded-full bg-emerald-500"></span>
-              Live
-            </div>
-          </div>
-
-          <div class="flex-1 overflow-y-auto px-6 md:px-10 py-8 space-y-6 text-sm">
-            <div class="space-y-2">
-              <p class="text-xs uppercase tracking-wide text-ink/40">You · 9:18</p>
-              <div class="max-w-xl rounded-2xl border border-ink/10 bg-ink/5 px-5 py-4 text-ink/80">
-                What did we learn from the Chef counter livestream?
+            <div class="space-y-3 text-sm text-white/80">
+              <div class="flex items-center justify-between rounded-2xl bg-white/10 px-4 py-3">
+                <span>Data freshness</span>
+                <span class="inline-flex items-center gap-2 rounded-full bg-emerald-400/20 px-3 py-1 text-xs text-emerald-200">
+                  <span class="h-2 w-2 rounded-full bg-emerald-400"></span>
+                  5 min ago
+                </span>
               </div>
-            </div>
-            <div class="space-y-2">
-              <p class="text-xs uppercase tracking-wide text-ink/40">Genie · 9:18</p>
-              <div class="max-w-2xl rounded-2xl bg-bubble text-white px-5 py-4">
-                <p class="font-semibold">Livestream recap</p>
-                <ul class="mt-2 list-disc space-y-1 pl-4 text-sm">
-                  <li>251 peak viewers with average watch time of 6m 12s (25% above goal).</li>
-                  <li>72 live chat comments → 19 same-night reservations.</li>
-                  <li>Menu spotlight: pad kee mao + mango sticky rice drove 42% of orders.</li>
-                  <li>Recommendation: clip the best Q&amp;A moments into a TikTok duet series.</li>
+              <div class="rounded-2xl bg-white/10 px-4 py-3">
+                <p class="text-xs uppercase tracking-wide text-white/50">Focus areas</p>
+                <ul class="mt-2 space-y-1">
+                  <li>• Midnight Market momentum</li>
+                  <li>• Loyalty bouncebacks</li>
+                  <li>• Competitor watch</li>
                 </ul>
               </div>
             </div>
-            <div class="space-y-2">
-              <p class="text-xs uppercase tracking-wide text-ink/40">You · 9:21</p>
-              <div class="max-w-xl rounded-2xl border border-ink/10 bg-ink/5 px-5 py-4 text-ink/80">
-                Suggest a follow-up experiment to capture late night demand.
+            <div class="space-y-3 text-sm text-white/80">
+              <h3 class="text-sm font-semibold text-white">Recommended prompts</h3>
+              <button class="w-full rounded-2xl bg-white/10 px-4 py-3 text-left hover:bg-white/15 transition">
+                Summarize finals-week demand signals
+              </button>
+              <button class="w-full rounded-2xl bg-white/10 px-4 py-3 text-left hover:bg-white/15 transition">
+                Draft a TikTok reply to Thai Tom fans
+              </button>
+              <button class="w-full rounded-2xl bg-white/10 px-4 py-3 text-left hover:bg-white/15 transition">
+                Suggest a loyalty win-back offer
+              </button>
+            </div>
+          </aside>
+
+          <div class="rounded-3xl bg-white/10 p-6 lg:p-8 flex flex-col backdrop-blur-sm shadow-[0_20px_45px_-30px_rgba(129,140,248,0.55)] ring-1 ring-white/10">
+            <div class="flex flex-wrap items-center justify-between gap-3 border-b border-white/10 pb-4">
+              <div>
+                <h1 class="text-2xl font-semibold">Ask Genie anything</h1>
+                <p class="text-sm text-white/60">Replies stay in Suit and Thai voice with grounded data.</p>
+              </div>
+              <div class="inline-flex items-center gap-2 rounded-full bg-white/10 px-3 py-1 text-xs text-white/75">
+                <span class="h-2 w-2 rounded-full bg-emerald-400"></span>
+                Live
               </div>
             </div>
-            <div class="space-y-2">
-              <p class="text-xs uppercase tracking-wide text-ink/40">Genie · 9:21</p>
-              <div class="max-w-2xl rounded-2xl bg-bubble text-white px-5 py-4 space-y-2">
-                <p class="font-semibold">Experiment: Midnight Market Beta</p>
-                <p>
-                  Offer a limited "study break" bundle from 9:30p–11p with dual-channel promo (TikTok + SMS). Cap at 45 bundles to test ops throughput.
-                </p>
-                <div class="rounded-2xl bg-white/10 px-4 py-3 text-sm">
-                  <p class="font-medium">Next steps</p>
-                  <ul class="mt-2 list-disc space-y-1 pl-4">
-                    <li>Auto-sync to Experiments board</li>
-                    <li>Prep queue script for floor leads</li>
-                    <li>Collect post-order 1-question pulse</li>
+
+            <div class="flex-1 overflow-y-auto py-6 space-y-5 text-sm text-white/80">
+              <div class="space-y-2">
+                <p class="text-xs text-white/50">You · 9:18p</p>
+                <div class="max-w-xl rounded-2xl bg-white/10 px-4 py-3">
+                  What did we learn from the Chef counter livestream?
+                </div>
+              </div>
+              <div class="space-y-2">
+                <p class="text-xs text-white/50">Genie · 9:18p</p>
+                <div class="max-w-2xl rounded-2xl bg-gradient-to-br from-sky-500/40 via-sky-500/15 to-white/10 px-5 py-4 space-y-2">
+                  <p class="font-semibold text-white">Livestream recap</p>
+                  <ul class="list-disc space-y-1 pl-4">
+                    <li>251 peak viewers with average watch time of 6m 12s (25% above goal).</li>
+                    <li>72 live chat comments → 19 same-night reservations.</li>
+                    <li>Menu spotlight: pad kee mao + mango sticky rice drove 42% of orders.</li>
+                    <li>Recommendation: clip the best Q&A moments into a TikTok duet series.</li>
                   </ul>
                 </div>
               </div>
+              <div class="space-y-2">
+                <p class="text-xs text-white/50">You · 9:21p</p>
+                <div class="max-w-xl rounded-2xl bg-white/10 px-4 py-3">
+                  Suggest a follow-up experiment to capture late night demand.
+                </div>
+              </div>
+              <div class="space-y-2">
+                <p class="text-xs text-white/50">Genie · 9:21p</p>
+                <div class="max-w-2xl rounded-2xl bg-gradient-to-br from-indigo-500/45 via-indigo-500/15 to-white/10 px-5 py-4 space-y-2">
+                  <p class="font-semibold text-white">Experiment: Midnight Market Beta</p>
+                  <p>
+                    Offer a limited "study break" bundle from 9:30p–11p with dual-channel promo (TikTok + SMS). Cap at 45 bundles to test ops throughput.
+                  </p>
+                  <div class="rounded-2xl bg-white/10 px-4 py-3 text-sm">
+                    <p class="font-medium text-white">Next steps</p>
+                    <ul class="mt-2 list-disc space-y-1 pl-4">
+                      <li>Auto-sync to Experiments board</li>
+                      <li>Prep queue script for floor leads</li>
+                      <li>Collect post-order 1-question pulse</li>
+                    </ul>
+                  </div>
+                </div>
+              </div>
             </div>
-          </div>
 
-          <form class="border-t border-ink/10 px-6 md:px-10 py-5 space-y-3" onsubmit="event.preventDefault();">
-            <div class="flex flex-wrap items-center justify-between gap-3 text-xs text-ink/50">
-              <span>Genie responds with Suit and Thai data, refreshed hourly.</span>
-              <button type="button" class="inline-flex items-center gap-2 rounded-full border border-ink/10 px-3 py-1 hover:bg-ink/5 transition">
-                <svg xmlns="http://www.w3.org/2000/svg" class="h-3.5 w-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                  <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M7 16V4m0 0L3 8m4-4l4 4" />
-                </svg>
-                Pull latest data
-              </button>
-            </div>
-            <div class="flex items-end gap-3">
-              <textarea
-                rows="2"
-                class="flex-1 rounded-2xl border border-ink/10 bg-white px-4 py-3 text-sm text-ink focus:border-ink/40 focus:outline-none"
-                placeholder="Ask Genie anything…"
-              ></textarea>
-              <button type="submit" class="inline-flex items-center gap-2 rounded-full bg-ink text-white px-6 py-3 text-sm font-semibold hover:bg-ink/80 transition">
-                Send
-                <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                  <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M5 12h14M12 5l7 7-7 7" />
-                </svg>
-              </button>
-            </div>
-          </form>
-        </div>
+            <form class="border-t border-white/10 pt-4 space-y-3" onsubmit="event.preventDefault();">
+              <div class="flex flex-wrap items-center justify-between gap-3 text-xs text-white/60">
+                <span>Genie responds with Suit and Thai data, refreshed hourly.</span>
+                <button type="button" class="inline-flex items-center gap-2 rounded-full border border-white/25 px-3 py-1 hover:border-white/60 transition">
+                  <svg xmlns="http://www.w3.org/2000/svg" class="h-3.5 w-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M7 16V4m0 0L3 8m4-4l4 4" />
+                  </svg>
+                  Pull latest data
+                </button>
+              </div>
+              <div class="flex items-end gap-3">
+                <textarea
+                  rows="2"
+                  class="flex-1 rounded-2xl border border-white/20 bg-transparent px-4 py-3 text-sm text-white placeholder:text-white/40 focus:border-white focus:outline-none"
+                  placeholder="Ask Genie anything…"
+                ></textarea>
+                <button type="submit" class="inline-flex items-center gap-2 rounded-full bg-white text-black px-6 py-3 text-sm font-semibold hover:bg-white/90 transition">
+                  Send
+                  <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M5 12h14M12 5l7 7-7 7" />
+                  </svg>
+                </button>
+              </div>
+            </form>
+          </div>
+        </section>
       </main>
     </div>
   </body>

--- a/competitors.html
+++ b/competitors.html
@@ -9,7 +9,7 @@
         theme: {
           extend: {
             fontFamily: {
-              script: ['"Dancing Script"', 'cursive'],
+              script: ['"Pacifico"', '"Allura"', 'cursive'],
               sans: ['"Manrope"', 'system-ui', 'sans-serif'],
             },
             colors: {
@@ -24,16 +24,12 @@
     <script src="https://cdn.tailwindcss.com"></script>
     <link
       rel="stylesheet"
-      href="https://fonts.googleapis.com/css2?family=Dancing+Script:wght@500;600&family=Manrope:wght@400;500;600;700&display=swap"
+      href="https://fonts.googleapis.com/css2?family=Allura&family=Manrope:wght@400;500;600;700&family=Pacifico&display=swap"
     />
     <style>
       body {
         background: radial-gradient(circle at top left, rgba(59, 130, 246, 0.18), transparent 45%),
           radial-gradient(circle at top right, rgba(147, 51, 234, 0.16), transparent 50%), #050508;
-      }
-      .scroll-smooth-touch {
-        scroll-snap-type: x mandatory;
-        -webkit-overflow-scrolling: touch;
       }
     </style>
   </head>
@@ -50,7 +46,7 @@
               <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M15 19l-7-7 7-7" />
             </svg>
           </button>
-          <div class="text-4xl font-script leading-none text-white">genie</div>
+          <div class="text-4xl font-script leading-none text-white tracking-wide">genie</div>
         </div>
         <div class="text-right">
           <p class="text-sm text-white/70">Your AI business advisor</p>
@@ -60,184 +56,427 @@
       <main class="flex-1 py-10 flex flex-col gap-12">
         <section class="max-w-4xl">
           <h1 class="text-5xl md:text-6xl font-light">Competitors</h1>
-          <p class="mt-3 text-base text-white/70">Swipe through the landscape and tap insights to act.</p>
+          <p class="mt-3 text-base text-white/70">Clean snapshot of who is moving and where we can outplay.</p>
         </section>
 
-        <section class="rounded-[32px] border border-outline/60 bg-surface backdrop-blur-xl p-8 space-y-8">
+        <section class="space-y-12">
+          <div class="grid gap-6 md:grid-cols-2 xl:grid-cols-4">
+            <article class="rounded-3xl bg-white/10 p-6 shadow-[0_20px_35px_-25px_rgba(59,130,246,0.55)] space-y-5">
+              <div class="flex items-center justify-between">
+                <h3 class="text-xl font-semibold">Thai Tom</h3>
+                <span class="rounded-full bg-white/15 px-3 py-1 text-xs text-white/80">4.6 ★</span>
+              </div>
+              <p class="text-sm text-white/70">Iconic counter spot with cult lines. Night menu drop drove +9% buzz.</p>
+              <ul class="space-y-2 text-sm text-white/75">
+                <li class="flex items-center justify-between">
+                  <span>Wait time</span>
+                  <span class="rounded-full bg-white/10 px-3 py-1 text-xs">30 min</span>
+                </li>
+                <li class="flex items-center justify-between">
+                  <span>Avg check</span>
+                  <span class="rounded-full bg-white/10 px-3 py-1 text-xs">$19</span>
+                </li>
+                <li class="flex items-center justify-between">
+                  <span>Signature play</span>
+                  <span class="rounded-full bg-white/10 px-3 py-1 text-xs">Late-night wok show</span>
+                </li>
+              </ul>
+            </article>
+            <article class="rounded-3xl bg-white/10 p-6 shadow-[0_20px_35px_-25px_rgba(147,197,253,0.5)] space-y-5">
+              <div class="flex items-center justify-between">
+                <h3 class="text-xl font-semibold">Pinto Bistro</h3>
+                <span class="rounded-full bg-white/15 px-3 py-1 text-xs text-white/80">4.4 ★</span>
+              </div>
+              <p class="text-sm text-white/70">Neighborhood favorite leaning into PR. Brunch collabs fueling awareness.</p>
+              <ul class="space-y-2 text-sm text-white/75">
+                <li class="flex items-center justify-between">
+                  <span>Wait time</span>
+                  <span class="rounded-full bg-white/10 px-3 py-1 text-xs">15 min</span>
+                </li>
+                <li class="flex items-center justify-between">
+                  <span>Avg check</span>
+                  <span class="rounded-full bg-white/10 px-3 py-1 text-xs">$24</span>
+                </li>
+                <li class="flex items-center justify-between">
+                  <span>Signature play</span>
+                  <span class="rounded-full bg-white/10 px-3 py-1 text-xs">Chef tasting nights</span>
+                </li>
+              </ul>
+            </article>
+            <article class="rounded-3xl bg-white/10 p-6 shadow-[0_20px_35px_-25px_rgba(167,139,250,0.5)] space-y-5">
+              <div class="flex items-center justify-between">
+                <h3 class="text-xl font-semibold">Lanna House</h3>
+                <span class="rounded-full bg-white/15 px-3 py-1 text-xs text-white/80">4.7 ★</span>
+              </div>
+              <p class="text-sm text-white/70">Elevated dining with patio expansion. Influencer dinner series launching.</p>
+              <ul class="space-y-2 text-sm text-white/75">
+                <li class="flex items-center justify-between">
+                  <span>Wait time</span>
+                  <span class="rounded-full bg-white/10 px-3 py-1 text-xs">20 min</span>
+                </li>
+                <li class="flex items-center justify-between">
+                  <span>Avg check</span>
+                  <span class="rounded-full bg-white/10 px-3 py-1 text-xs">$32</span>
+                </li>
+                <li class="flex items-center justify-between">
+                  <span>Signature play</span>
+                  <span class="rounded-full bg-white/10 px-3 py-1 text-xs">Garden patio parties</span>
+                </li>
+              </ul>
+            </article>
+            <article class="rounded-3xl bg-white/10 p-6 shadow-[0_20px_35px_-25px_rgba(129,140,248,0.5)] space-y-5">
+              <div class="flex items-center justify-between">
+                <h3 class="text-xl font-semibold">Kin Khao Express</h3>
+                <span class="rounded-full bg-white/15 px-3 py-1 text-xs text-white/80">4.5 ★</span>
+              </div>
+              <p class="text-sm text-white/70">Ghost-kitchen forward with speedy delivery. Heat-and-serve kits trending.</p>
+              <ul class="space-y-2 text-sm text-white/75">
+                <li class="flex items-center justify-between">
+                  <span>Wait time</span>
+                  <span class="rounded-full bg-white/10 px-3 py-1 text-xs">Delivery only</span>
+                </li>
+                <li class="flex items-center justify-between">
+                  <span>Avg check</span>
+                  <span class="rounded-full bg-white/10 px-3 py-1 text-xs">$27</span>
+                </li>
+                <li class="flex items-center justify-between">
+                  <span>Signature play</span>
+                  <span class="rounded-full bg-white/10 px-3 py-1 text-xs">Family heat kits</span>
+                </li>
+              </ul>
+            </article>
+          </div>
+
           <div class="flex flex-wrap items-center justify-between gap-4">
-            <h2 class="text-2xl font-semibold">Comparison rail</h2>
-            <div class="relative">
+            <div class="inline-flex rounded-full bg-white/5 p-1 text-sm">
+              <button class="tab-trigger rounded-full px-4 py-2 font-medium bg-white text-black" data-target="competitors-strategy">
+                Strategy
+              </button>
+              <button class="tab-trigger rounded-full px-4 py-2 font-medium text-white/70 hover:text-white transition" data-target="competitors-dashboard">
+                Dashboard
+              </button>
+            </div>
+            <span class="text-sm text-white/60">Listening across 38 data sources</span>
+          </div>
+
+          <div id="competitors-strategy" class="tab-panel space-y-10">
+            <div class="flex flex-wrap items-start justify-between gap-6">
+              <div>
+                <h2 class="text-2xl font-semibold">Strategy</h2>
+                <p class="mt-2 text-white/65 max-w-2xl">Anchor on Suit and Thai advantages while watching competitor spikes in real time.</p>
+              </div>
               <button
-                id="competitor-ai-button"
-                class="inline-flex items-center gap-2 rounded-full bg-rose-500 px-4 py-2 text-sm font-semibold shadow-lg hover:bg-rose-400 transition"
                 type="button"
+                class="competitor-ai-trigger inline-flex items-center gap-2 rounded-full bg-rose-500 px-4 py-2 text-sm font-semibold shadow-lg hover:bg-rose-400 transition"
+                data-label="Landscape overview"
               >
                 <span class="inline-block h-2 w-2 rounded-full bg-white animate-pulse"></span>
                 AI suggestion
               </button>
-              <div
-                id="competitor-ai-menu"
-                class="absolute right-0 mt-3 hidden w-48 rounded-2xl border border-white/20 bg-night/95 p-3 text-sm shadow-2xl"
-              >
-                <button class="menu-option flex w-full items-center gap-2 rounded-xl px-3 py-2 text-left text-white/80 hover:bg-white/10" data-action="change">
-                  <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.6" d="M4 7h16M4 12h16m-8 5h8" />
-                  </svg>
-                  Change positioning
-                </button>
-                <button class="menu-option flex w-full items-center gap-2 rounded-xl px-3 py-2 text-left text-white/80 hover:bg-white/10" data-action="experiment">
-                  <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.6" d="M12 6v12m6-6H6" />
-                  </svg>
-                  Add to experiment
-                </button>
+            </div>
+
+            <div class="grid gap-6 lg:grid-cols-[1.1fr,0.9fr]">
+              <div class="space-y-6">
+                <div class="rounded-3xl bg-white/10 p-6 backdrop-blur-sm space-y-5">
+                  <h3 class="text-xl font-semibold">Competitor watchlist</h3>
+                  <div class="grid gap-4 sm:grid-cols-2 text-sm text-white/80">
+                    <div class="rounded-2xl bg-white/10 p-4 space-y-2">
+                      <div class="flex items-center justify-between">
+                        <p class="font-semibold text-white">Thai Tom</p>
+                        <span class="rounded-full bg-emerald-400/20 px-3 py-1 text-xs text-emerald-200">Hot</span>
+                      </div>
+                      <p class="text-white/65">Night wok show content spiking 32% shares.</p>
+                      <button
+                        type="button"
+                        class="competitor-ai-trigger inline-flex items-center gap-1 rounded-full bg-white/15 px-3 py-1 text-[11px] font-medium text-white/80 hover:bg-white/25 transition"
+                        data-label="Thai Tom"
+                      >
+                        <svg xmlns="http://www.w3.org/2000/svg" class="h-3.5 w-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M12 3v3m0 12v3m9-9h-3M6 12H3m15.364 6.364-2.121-2.121M8.757 8.757 6.636 6.636m12.728 0-2.121 2.121M8.757 15.243l-2.121 2.121" />
+                        </svg>
+                        Genie tip
+                      </button>
+                    </div>
+                    <div class="rounded-2xl bg-white/10 p-4 space-y-2">
+                      <div class="flex items-center justify-between">
+                        <p class="font-semibold text-white">Pinto Bistro</p>
+                        <span class="rounded-full bg-sky-400/20 px-3 py-1 text-xs text-sky-200">Watch</span>
+                      </div>
+                      <p class="text-white/65">Weekend brunch PR adds 11 earned hits in 14 days.</p>
+                      <button
+                        type="button"
+                        class="competitor-ai-trigger inline-flex items-center gap-1 rounded-full bg-white/15 px-3 py-1 text-[11px] font-medium text-white/80 hover:bg-white/25 transition"
+                        data-label="Pinto Bistro"
+                      >
+                        <svg xmlns="http://www.w3.org/2000/svg" class="h-3.5 w-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M12 3v3m0 12v3m9-9h-3M6 12H3m15.364 6.364-2.121-2.121M8.757 8.757 6.636 6.636m12.728 0-2.121 2.121M8.757 15.243l-2.121 2.121" />
+                        </svg>
+                        Genie tip
+                      </button>
+                    </div>
+                    <div class="rounded-2xl bg-white/10 p-4 space-y-2">
+                      <div class="flex items-center justify-between">
+                        <p class="font-semibold text-white">Lanna House</p>
+                        <span class="rounded-full bg-violet-400/20 px-3 py-1 text-xs text-violet-200">Emerging</span>
+                      </div>
+                      <p class="text-white/65">Patio expansion event series starts in 3 weeks.</p>
+                      <button
+                        type="button"
+                        class="competitor-ai-trigger inline-flex items-center gap-1 rounded-full bg-white/15 px-3 py-1 text-[11px] font-medium text-white/80 hover:bg-white/25 transition"
+                        data-label="Lanna House"
+                      >
+                        <svg xmlns="http://www.w3.org/2000/svg" class="h-3.5 w-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M12 3v3m0 12v3m9-9h-3M6 12H3m15.364 6.364-2.121-2.121M8.757 8.757 6.636 6.636m12.728 0-2.121 2.121M8.757 15.243l-2.121 2.121" />
+                        </svg>
+                        Genie tip
+                      </button>
+                    </div>
+                    <div class="rounded-2xl bg-white/10 p-4 space-y-2">
+                      <div class="flex items-center justify-between">
+                        <p class="font-semibold text-white">Kin Khao Express</p>
+                        <span class="rounded-full bg-indigo-400/20 px-3 py-1 text-xs text-indigo-200">Steady</span>
+                      </div>
+                      <p class="text-white/65">Heat-and-serve kits testing family bundle upsell.</p>
+                      <button
+                        type="button"
+                        class="competitor-ai-trigger inline-flex items-center gap-1 rounded-full bg-white/15 px-3 py-1 text-[11px] font-medium text-white/80 hover:bg-white/25 transition"
+                        data-label="Kin Khao Express"
+                      >
+                        <svg xmlns="http://www.w3.org/2000/svg" class="h-3.5 w-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M12 3v3m0 12v3m9-9h-3M6 12H3m15.364 6.364-2.121-2.121M8.757 8.757 6.636 6.636m12.728 0-2.121 2.121M8.757 15.243l-2.121 2.121" />
+                        </svg>
+                        Genie tip
+                      </button>
+                    </div>
+                  </div>
+                </div>
+
+                <div class="rounded-3xl bg-white/10 p-6 backdrop-blur-sm space-y-4">
+                  <h3 class="text-xl font-semibold">AI insights / thoughts</h3>
+                  <ul class="space-y-3 text-sm text-white/75">
+                    <li class="flex gap-3">
+                      <span class="mt-1 h-2.5 w-2.5 rounded-full bg-rose-400"></span>
+                      Thai Tom's late-night content spikes align with our own midnight orders — stack counter-programming around chef storytelling.
+                    </li>
+                    <li class="flex gap-3">
+                      <span class="mt-1 h-2.5 w-2.5 rounded-full bg-sky-400"></span>
+                      Pinto Bistro is winning brunch press; pivot our narrative to "study sanctuary" to avoid overlap.
+                    </li>
+                    <li class="flex gap-3">
+                      <span class="mt-1 h-2.5 w-2.5 rounded-full bg-emerald-400"></span>
+                      Kin Khao Express heat kits earn 4.8★ — offer our own finals bundle with dine-in pickup to intercept loyalty.
+                    </li>
+                  </ul>
+                </div>
               </div>
+
+              <aside class="rounded-3xl bg-white/10 p-6 backdrop-blur-sm space-y-5">
+                <h3 class="text-xl font-semibold">Action queue</h3>
+                <ul class="space-y-4 text-sm text-white/75">
+                  <li class="rounded-2xl bg-white/10 p-4">
+                    <div class="flex items-center justify-between">
+                      <p class="font-semibold text-white">Repurpose livestream Q&A</p>
+                      <span class="rounded-full bg-emerald-400/20 px-3 py-1 text-xs text-emerald-200">Due today</span>
+                    </div>
+                    <p class="mt-2 text-white/60">Clip 3 highlights to counter Thai Tom's reel momentum.</p>
+                  </li>
+                  <li class="rounded-2xl bg-white/10 p-4">
+                    <div class="flex items-center justify-between">
+                      <p class="font-semibold text-white">Pitch finals sanctuary story</p>
+                      <span class="rounded-full bg-sky-400/20 px-3 py-1 text-xs text-sky-200">In progress</span>
+                    </div>
+                    <p class="mt-2 text-white/60">Frame around "quiet study nights" to differentiate from Pinto Bistro.</p>
+                  </li>
+                  <li class="rounded-2xl bg-white/10 p-4">
+                    <div class="flex items-center justify-between">
+                      <p class="font-semibold text-white">Catering follow-up</p>
+                      <span class="rounded-full bg-amber-400/20 px-3 py-1 text-xs text-amber-200">Tomorrow</span>
+                    </div>
+                    <p class="mt-2 text-white/60">Offer finals bundle tasting to tech offices before Kin Khao kits roll out.</p>
+                  </li>
+                </ul>
+              </aside>
             </div>
           </div>
 
-          <div class="-mx-2 overflow-x-auto scroll-smooth-touch pb-4">
-            <div class="flex gap-6 px-2">
-              <article class="snap-start shrink-0 min-w-[260px] rounded-[28px] border border-outline bg-white/5 p-6">
-                <div class="flex items-center justify-between">
-                  <h3 class="text-xl font-semibold">Thai Tom</h3>
-                  <span class="rounded-full bg-white/10 px-3 py-1 text-xs text-white/70">4.6 ★</span>
-                </div>
-                <p class="mt-4 text-sm text-white/70">Iconic counter spot with cult lines. Recent late-night menu drop drove a 9% buzz lift.</p>
-                <dl class="mt-5 space-y-2 text-sm text-white/75">
-                  <div class="flex items-center justify-between">
-                    <dt>Wait time</dt>
-                    <dd class="rounded-full bg-white/10 px-3 py-1 text-xs">30 min</dd>
-                  </div>
-                  <div class="flex items-center justify-between">
-                    <dt>Avg check</dt>
-                    <dd class="rounded-full bg-white/10 px-3 py-1 text-xs">$19</dd>
-                  </div>
-                  <div class="flex items-center justify-between">
-                    <dt>Signature play</dt>
-                    <dd class="rounded-full bg-white/10 px-3 py-1 text-xs">Late-night wok show</dd>
-                  </div>
-                </dl>
-              </article>
-
-              <article class="snap-start shrink-0 min-w-[260px] rounded-[28px] border border-outline bg-white/5 p-6">
-                <div class="flex items-center justify-between">
-                  <h3 class="text-xl font-semibold">Pinto Bistro</h3>
-                  <span class="rounded-full bg-white/10 px-3 py-1 text-xs text-white/70">4.4 ★</span>
-                </div>
-                <p class="mt-4 text-sm text-white/70">Neighborhood favorite leaning into high-touch PR. Paid ads up 6% with brunch collabs.</p>
-                <dl class="mt-5 space-y-2 text-sm text-white/75">
-                  <div class="flex items-center justify-between">
-                    <dt>Wait time</dt>
-                    <dd class="rounded-full bg-white/10 px-3 py-1 text-xs">15 min</dd>
-                  </div>
-                  <div class="flex items-center justify-between">
-                    <dt>Avg check</dt>
-                    <dd class="rounded-full bg-white/10 px-3 py-1 text-xs">$24</dd>
-                  </div>
-                  <div class="flex items-center justify-between">
-                    <dt>Signature play</dt>
-                    <dd class="rounded-full bg-white/10 px-3 py-1 text-xs">Chef tasting nights</dd>
-                  </div>
-                </dl>
-              </article>
-
-              <article class="snap-start shrink-0 min-w-[260px] rounded-[28px] border border-outline bg-white/5 p-6">
-                <div class="flex items-center justify-between">
-                  <h3 class="text-xl font-semibold">Lanna House</h3>
-                  <span class="rounded-full bg-white/10 px-3 py-1 text-xs text-white/70">4.7 ★</span>
-                </div>
-                <p class="mt-4 text-sm text-white/70">Elevated dining with patio expansion underway. Influencer dinner series launching.</p>
-                <dl class="mt-5 space-y-2 text-sm text-white/75">
-                  <div class="flex items-center justify-between">
-                    <dt>Wait time</dt>
-                    <dd class="rounded-full bg-white/10 px-3 py-1 text-xs">20 min</dd>
-                  </div>
-                  <div class="flex items-center justify-between">
-                    <dt>Avg check</dt>
-                    <dd class="rounded-full bg-white/10 px-3 py-1 text-xs">$32</dd>
-                  </div>
-                  <div class="flex items-center justify-between">
-                    <dt>Signature play</dt>
-                    <dd class="rounded-full bg-white/10 px-3 py-1 text-xs">Garden patio parties</dd>
-                  </div>
-                </dl>
-              </article>
-
-              <article class="snap-start shrink-0 min-w-[260px] rounded-[28px] border border-outline bg-white/5 p-6">
-                <div class="flex items-center justify-between">
-                  <h3 class="text-xl font-semibold">Kin Khao Express</h3>
-                  <span class="rounded-full bg-white/10 px-3 py-1 text-xs text-white/70">4.5 ★</span>
-                </div>
-                <p class="mt-4 text-sm text-white/70">Ghost-kitchen forward with speedy delivery. Experimenting with heat-and-serve kits.</p>
-                <dl class="mt-5 space-y-2 text-sm text-white/75">
-                  <div class="flex items-center justify-between">
-                    <dt>Wait time</dt>
-                    <dd class="rounded-full bg-white/10 px-3 py-1 text-xs">Delivery only</dd>
-                  </div>
-                  <div class="flex items-center justify-between">
-                    <dt>Avg check</dt>
-                    <dd class="rounded-full bg-white/10 px-3 py-1 text-xs">$27</dd>
-                  </div>
-                  <div class="flex items-center justify-between">
-                    <dt>Signature play</dt>
-                    <dd class="rounded-full bg-white/10 px-3 py-1 text-xs">Family heat kits</dd>
-                  </div>
-                </dl>
-              </article>
+          <div id="competitors-dashboard" class="tab-panel hidden space-y-10">
+            <div class="grid gap-6 md:grid-cols-4">
+              <div class="rounded-3xl bg-white/5 p-6 text-center shadow-[0_18px_30px_-25px_rgba(59,130,246,0.45)]">
+                <p class="text-sm text-white/60">Search share</p>
+                <p class="mt-3 text-3xl font-semibold">42%</p>
+                <p class="mt-2 text-sm text-emerald-300">Suit &amp; Thai +3%</p>
+              </div>
+              <div class="rounded-3xl bg-white/5 p-6 text-center shadow-[0_18px_30px_-25px_rgba(147,197,253,0.45)]">
+                <p class="text-sm text-white/60">Social buzz</p>
+                <p class="mt-3 text-3xl font-semibold">33%</p>
+                <p class="mt-2 text-sm text-emerald-300">Chef content trending</p>
+              </div>
+              <div class="rounded-3xl bg-white/5 p-6 text-center shadow-[0_18px_30px_-25px_rgba(167,139,250,0.45)]">
+                <p class="text-sm text-white/60">Press hits</p>
+                <p class="mt-3 text-3xl font-semibold">25%</p>
+                <p class="mt-2 text-sm text-emerald-300">Night Market story pending</p>
+              </div>
+              <div class="rounded-3xl bg-white/5 p-6 text-center shadow-[0_18px_30px_-25px_rgba(129,140,248,0.45)]">
+                <p class="text-sm text-white/60">Sentiment</p>
+                <p class="mt-3 text-3xl font-semibold">4.6 ★</p>
+                <p class="mt-2 text-sm text-emerald-300">Pad kee mao keywords</p>
+              </div>
             </div>
-          </div>
 
-          <div class="rounded-[28px] border border-outline bg-white/5 p-7 space-y-6">
-            <div class="flex flex-wrap items-center justify-between gap-4">
-              <h3 class="text-xl font-semibold">Signals dashboard</h3>
-              <span class="text-sm text-white/60">Source: public reviews · social listening</span>
-            </div>
-            <div class="grid gap-6 md:grid-cols-4 text-center text-sm text-white/75">
-              <div class="rounded-2xl bg-white/5 p-5">
-                <p class="text-sm font-semibold text-white/80">Search share</p>
-                <p class="mt-3 text-2xl font-semibold">42%</p>
-                <p class="mt-2 text-xs text-emerald-300">Suit &amp; Thai +3%</p>
+            <div class="grid gap-6 lg:grid-cols-[1.05fr,0.95fr]">
+              <div class="rounded-3xl bg-white/10 p-7 backdrop-blur-sm space-y-6">
+                <div class="flex items-center justify-between">
+                  <h3 class="text-xl font-semibold">Playbook vs rivals</h3>
+                  <span class="text-xs text-white/60">Updated hourly</span>
+                </div>
+                <div class="space-y-4 text-sm text-white/75">
+                  <div class="flex items-center justify-between gap-4">
+                    <div>
+                      <p class="font-semibold text-white/85">Awareness lift</p>
+                      <p class="text-xs text-white/50">Suit &amp; Thai vs Thai Tom</p>
+                    </div>
+                    <div class="flex-1 h-2 rounded-full bg-white/10">
+                      <div class="h-2 rounded-full bg-emerald-400" style="width: 68%"></div>
+                    </div>
+                    <span class="text-xs text-white/60">Goal 70%</span>
+                  </div>
+                  <div class="flex items-center justify-between gap-4">
+                    <div>
+                      <p class="font-semibold text-white/85">Conversion edge</p>
+                      <p class="text-xs text-white/50">Waitlist → seat</p>
+                    </div>
+                    <div class="flex-1 h-2 rounded-full bg-white/10">
+                      <div class="h-2 rounded-full bg-sky-400" style="width: 74%"></div>
+                    </div>
+                    <span class="text-xs text-white/60">Goal 80%</span>
+                  </div>
+                  <div class="flex items-center justify-between gap-4">
+                    <div>
+                      <p class="font-semibold text-white/85">Loyalty moat</p>
+                      <p class="text-xs text-white/50">Repeat visits</p>
+                    </div>
+                    <div class="flex-1 h-2 rounded-full bg-white/10">
+                      <div class="h-2 rounded-full bg-violet-400" style="width: 82%"></div>
+                    </div>
+                    <span class="text-xs text-white/60">Goal 85%</span>
+                  </div>
+                </div>
               </div>
-              <div class="rounded-2xl bg-white/5 p-5">
-                <p class="text-sm font-semibold text-white/80">Social buzz</p>
-                <p class="mt-3 text-2xl font-semibold">33%</p>
-                <p class="mt-2 text-xs text-emerald-300">Chef content trending</p>
-              </div>
-              <div class="rounded-2xl bg-white/5 p-5">
-                <p class="text-sm font-semibold text-white/80">Press hits</p>
-                <p class="mt-3 text-2xl font-semibold">25%</p>
-                <p class="mt-2 text-xs text-emerald-300">Night Market story pending</p>
-              </div>
-              <div class="rounded-2xl bg-white/5 p-5">
-                <p class="text-sm font-semibold text-white/80">Sentiment</p>
-                <p class="mt-3 text-2xl font-semibold">4.6 ★</p>
-                <p class="mt-2 text-xs text-emerald-300">Friendly + pad kee mao keywords</p>
-              </div>
+
+              <aside class="rounded-3xl bg-white/10 p-7 backdrop-blur-sm space-y-5">
+                <div class="flex items-center justify-between">
+                  <h3 class="text-xl font-semibold">Signals</h3>
+                  <span class="text-xs text-white/60">Next sweep · 45m</span>
+                </div>
+                <ul class="space-y-4 text-sm text-white/75">
+                  <li class="flex items-center justify-between gap-4">
+                    <span>Review velocity</span>
+                    <span class="rounded-full bg-white/10 px-3 py-1 text-xs">+11 this week</span>
+                  </li>
+                  <li class="flex items-center justify-between gap-4">
+                    <span>Influencer chatter</span>
+                    <span class="rounded-full bg-white/10 px-3 py-1 text-xs">+7 posts</span>
+                  </li>
+                  <li class="flex items-center justify-between gap-4">
+                    <span>Offer overlap</span>
+                    <span class="rounded-full bg-white/10 px-3 py-1 text-xs">2 plays</span>
+                  </li>
+                  <li class="flex items-center justify-between gap-4">
+                    <span>Price delta</span>
+                    <span class="rounded-full bg-white/10 px-3 py-1 text-xs">+$3 avg</span>
+                  </li>
+                </ul>
+              </aside>
             </div>
           </div>
         </section>
       </main>
     </div>
 
+    <div id="competitor-ai-menu" class="hidden fixed z-50 w-60 rounded-2xl border border-white/15 bg-[#070b18] p-4 text-sm shadow-2xl">
+      <p class="text-xs uppercase tracking-wide text-white/50">Genie focus</p>
+      <p id="competitor-menu-context" class="mt-1 text-sm font-semibold text-white"></p>
+      <div class="mt-4 space-y-2">
+        <button class="competitor-menu-option flex w-full items-center gap-2 rounded-xl bg-white/10 px-3 py-2 text-left text-white/80 hover:bg-white/20 transition" data-action="positioning">
+          <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.6" d="M4 7h16M4 12h16m-8 5h8" />
+          </svg>
+          Refresh positioning
+        </button>
+        <button class="competitor-menu-option flex w-full items-center gap-2 rounded-xl bg-white/10 px-3 py-2 text-left text-white/80 hover:bg-white/20 transition" data-action="experiment">
+          <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.6" d="M12 6v12m6-6H6" />
+          </svg>
+          Draft counter play
+        </button>
+      </div>
+    </div>
+
     <script>
-      const aiButton = document.getElementById('competitor-ai-button');
-      const aiMenu = document.getElementById('competitor-ai-menu');
-      aiButton?.addEventListener('click', (event) => {
-        event.stopPropagation();
-        aiMenu.classList.toggle('hidden');
+      const competitorTabs = document.querySelectorAll('.tab-trigger');
+      const competitorPanels = document.querySelectorAll('.tab-panel');
+      competitorTabs.forEach((button) => {
+        button.addEventListener('click', () => {
+          competitorTabs.forEach((btn) => btn.classList.remove('bg-white', 'text-black', 'text-white/70'));
+          button.classList.add('bg-white', 'text-black');
+          competitorTabs.forEach((btn) => btn !== button && btn.classList.add('text-white/70'));
+          competitorPanels.forEach((panel) => {
+            if (panel.id === button.dataset.target) {
+              panel.classList.remove('hidden');
+            } else {
+              panel.classList.add('hidden');
+            }
+          });
+        });
       });
+
+      const competitorMenu = document.getElementById('competitor-ai-menu');
+      const competitorMenuContext = document.getElementById('competitor-menu-context');
+      const competitorTriggers = document.querySelectorAll('.competitor-ai-trigger');
+      let competitorActiveTrigger = null;
+
+      function positionCompetitorMenu(trigger) {
+        const rect = trigger.getBoundingClientRect();
+        competitorMenu.style.top = `${rect.bottom + window.scrollY + 8}px`;
+        competitorMenu.style.left = `${Math.min(rect.left + window.scrollX, window.innerWidth - competitorMenu.offsetWidth - 16)}px`;
+      }
+
+      competitorTriggers.forEach((trigger) => {
+        trigger.addEventListener('click', (event) => {
+          event.stopPropagation();
+          const label = trigger.dataset.label || 'Landscape';
+          competitorMenuContext.textContent = label;
+          competitorActiveTrigger = trigger;
+          competitorMenu.classList.remove('hidden');
+          competitorMenu.style.display = 'block';
+          requestAnimationFrame(() => {
+            positionCompetitorMenu(trigger);
+          });
+        });
+      });
+
       document.addEventListener('click', (event) => {
-        if (!aiMenu.contains(event.target) && !aiButton.contains(event.target)) {
-          aiMenu.classList.add('hidden');
+        if (!competitorMenu.contains(event.target)) {
+          competitorMenu.classList.add('hidden');
+          competitorMenu.style.display = 'none';
+          competitorActiveTrigger = null;
         }
       });
-      const competitorOptions = document.querySelectorAll('#competitor-ai-menu .menu-option');
+
+      const competitorOptions = document.querySelectorAll('.competitor-menu-option');
       competitorOptions.forEach((option) => {
         option.addEventListener('click', () => {
-          aiMenu.classList.add('hidden');
+          competitorMenu.classList.add('hidden');
+          competitorMenu.style.display = 'none';
           const action = option.dataset.action;
-          alert(action === 'change' ? 'Genie drafted a repositioning outline.' : 'Competitor idea saved to Experiments.');
+          alert(action === 'positioning' ? 'Genie drafted a repositioning outline.' : 'Counter play saved to Experiments.');
         });
+      });
+
+      window.addEventListener('resize', () => {
+        if (!competitorMenu.classList.contains('hidden') && competitorActiveTrigger) {
+          positionCompetitorMenu(competitorActiveTrigger);
+        }
       });
     </script>
   </body>

--- a/demo.html
+++ b/demo.html
@@ -9,7 +9,7 @@
         theme: {
           extend: {
             fontFamily: {
-              script: ['"Dancing Script"', 'cursive'],
+              script: ['"Pacifico"', '"Allura"', 'cursive'],
               sans: ['"Manrope"', 'system-ui', 'sans-serif'],
             },
             colors: {
@@ -23,7 +23,7 @@
     <script src="https://cdn.tailwindcss.com"></script>
     <link
       rel="stylesheet"
-      href="https://fonts.googleapis.com/css2?family=Dancing+Script:wght@500;600&family=Manrope:wght@400;500;600;700&display=swap"
+      href="https://fonts.googleapis.com/css2?family=Allura&family=Manrope:wght@400;500;600;700&family=Pacifico&display=swap"
     />
     <style>
       body {
@@ -47,7 +47,7 @@
               <path stroke-linecap="round" stroke-linejoin="round" d="M3 10.5L12 4l9 6.5V20a1 1 0 01-1 1h-5.5a.5.5 0 01-.5-.5V15a2 2 0 00-2-2h-1a2 2 0 00-2 2v5.5a.5.5 0 01-.5.5H4a1 1 0 01-1-1v-9.5z" />
             </svg>
           </span>
-          <div class="text-5xl md:text-6xl font-script leading-none text-white">genie</div>
+          <div class="text-5xl md:text-6xl font-script leading-none text-white tracking-wide">genie</div>
         </div>
         <div class="text-right">
           <p class="text-sm text-white/70">Your AI business advisor</p>
@@ -56,7 +56,7 @@
 
       <main class="flex-1 px-6 md:px-12 py-16">
         <section class="max-w-4xl">
-          <h1 class="text-5xl md:text-6xl font-light mb-3">Hi Suit and Thai !!!</h1>
+          <h1 class="text-5xl md:text-6xl font-light mb-3">Hi Suit and Thai!</h1>
           <p class="text-base text-white/70">Tap an app to dive in.</p>
         </section>
 
@@ -65,15 +65,15 @@
           <div class="mx-auto max-w-6xl grid gap-6 grid-cols-2 md:grid-cols-3 xl:grid-cols-4 auto-rows-[210px]">
             <a
               href="marketing.html"
-              class="group relative flex flex-col justify-between overflow-hidden rounded-[22px] border border-white/20 bg-gradient-to-br from-pink-500/50 via-fuchsia-500/30 to-indigo-400/30 p-6 backdrop-blur-lg transition hover:-translate-y-1 hover:shadow-[0_20px_45px_-25px_rgba(255,0,128,0.75)]"
+              class="group relative flex flex-col justify-between overflow-hidden rounded-[22px] border border-white/15 bg-gradient-to-br from-pink-400/35 via-fuchsia-400/20 to-indigo-300/25 p-6 backdrop-blur-lg transition hover:-translate-y-1 hover:shadow-[0_20px_45px_-25px_rgba(255,0,128,0.6)]"
             >
               <div class="flex items-start justify-between">
-                <span class="inline-flex h-11 w-11 items-center justify-center rounded-2xl bg-white/15 text-white/95">
-                  <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                <span class="inline-flex h-12 w-12 items-center justify-center rounded-2xl bg-white/15 text-white/95">
+                  <svg xmlns="http://www.w3.org/2000/svg" class="h-6 w-6" fill="none" viewBox="0 0 24 24" stroke="currentColor">
                     <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M12 8c-1.105 0-2 .672-2 1.5S10.895 12 12 12m0-3c1.105 0 2 .672 2 1.5S13.105 12 12 12m0 0c-1.105 0-2 .672-2 1.5S10.895 15 12 15m0-3c1.105 0 2 .672 2 1.5S13.105 15 12 15m0 3v-3m0-6V6" />
                   </svg>
                 </span>
-                <svg class="h-5 w-5 text-white/70 transition group-hover:translate-x-1" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                <svg class="h-6 w-6 text-white/75 transition group-hover:translate-x-1" fill="none" viewBox="0 0 24 24" stroke="currentColor">
                   <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M9 5l7 7-7 7" />
                 </svg>
               </div>
@@ -82,15 +82,15 @@
 
             <a
               href="growth.html"
-              class="group relative flex flex-col justify-between overflow-hidden rounded-[22px] border border-white/20 bg-gradient-to-br from-emerald-400/50 via-teal-400/30 to-cyan-300/30 p-6 backdrop-blur-lg transition hover:-translate-y-1 hover:shadow-[0_20px_45px_-25px_rgba(16,185,129,0.85)]"
+              class="group relative flex flex-col justify-between overflow-hidden rounded-[22px] border border-white/15 bg-gradient-to-br from-emerald-400/35 via-teal-400/20 to-cyan-300/25 p-6 backdrop-blur-lg transition hover:-translate-y-1 hover:shadow-[0_20px_45px_-25px_rgba(16,185,129,0.65)]"
             >
               <div class="flex items-start justify-between">
-                <span class="inline-flex h-11 w-11 items-center justify-center rounded-2xl bg-white/15 text-white/95">
-                  <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                <span class="inline-flex h-12 w-12 items-center justify-center rounded-2xl bg-white/15 text-white/95">
+                  <svg xmlns="http://www.w3.org/2000/svg" class="h-6 w-6" fill="none" viewBox="0 0 24 24" stroke="currentColor">
                     <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M3 17l6-6 4 4 8-8" />
                   </svg>
                 </span>
-                <svg class="h-5 w-5 text-white/70 transition group-hover:translate-x-1" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                <svg class="h-6 w-6 text-white/75 transition group-hover:translate-x-1" fill="none" viewBox="0 0 24 24" stroke="currentColor">
                   <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M9 5l7 7-7 7" />
                 </svg>
               </div>
@@ -99,16 +99,16 @@
 
             <a
               href="competitors.html"
-              class="group relative flex flex-col justify-between overflow-hidden rounded-[22px] border border-white/20 bg-gradient-to-br from-sky-400/50 via-blue-400/30 to-purple-300/30 p-6 backdrop-blur-lg transition hover:-translate-y-1 hover:shadow-[0_20px_45px_-25px_rgba(56,189,248,0.8)]"
+              class="group relative flex flex-col justify-between overflow-hidden rounded-[22px] border border-white/15 bg-gradient-to-br from-sky-400/35 via-blue-400/20 to-purple-300/25 p-6 backdrop-blur-lg transition hover:-translate-y-1 hover:shadow-[0_20px_45px_-25px_rgba(56,189,248,0.65)]"
             >
               <div class="flex items-start justify-between">
-                <span class="inline-flex h-11 w-11 items-center justify-center rounded-2xl bg-white/15 text-white/95">
-                  <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                <span class="inline-flex h-12 w-12 items-center justify-center rounded-2xl bg-white/15 text-white/95">
+                  <svg xmlns="http://www.w3.org/2000/svg" class="h-6 w-6" fill="none" viewBox="0 0 24 24" stroke="currentColor">
                     <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M12 6l8 4-8 4-8-4 8-4z" />
                     <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M4 14l8 4 8-4" />
                   </svg>
                 </span>
-                <svg class="h-5 w-5 text-white/70 transition group-hover:translate-x-1" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                <svg class="h-6 w-6 text-white/75 transition group-hover:translate-x-1" fill="none" viewBox="0 0 24 24" stroke="currentColor">
                   <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M9 5l7 7-7 7" />
                 </svg>
               </div>
@@ -117,15 +117,15 @@
 
             <a
               href="inventory.html"
-              class="group relative flex flex-col justify-between overflow-hidden rounded-[22px] border border-white/20 bg-gradient-to-br from-orange-400/55 via-amber-300/30 to-yellow-200/30 p-6 backdrop-blur-lg transition hover:-translate-y-1 hover:shadow-[0_20px_45px_-25px_rgba(251,191,36,0.75)]"
+              class="group relative flex flex-col justify-between overflow-hidden rounded-[22px] border border-white/15 bg-gradient-to-br from-orange-400/35 via-amber-300/20 to-yellow-200/25 p-6 backdrop-blur-lg transition hover:-translate-y-1 hover:shadow-[0_20px_45px_-25px_rgba(251,191,36,0.6)]"
             >
               <div class="flex items-start justify-between">
-                <span class="inline-flex h-11 w-11 items-center justify-center rounded-2xl bg-white/15 text-white/95">
-                  <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                <span class="inline-flex h-12 w-12 items-center justify-center rounded-2xl bg-white/15 text-white/95">
+                  <svg xmlns="http://www.w3.org/2000/svg" class="h-6 w-6" fill="none" viewBox="0 0 24 24" stroke="currentColor">
                     <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M3 7h18M3 12h18M3 17h18" />
                   </svg>
                 </span>
-                <svg class="h-5 w-5 text-white/70 transition group-hover:translate-x-1" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                <svg class="h-6 w-6 text-white/75 transition group-hover:translate-x-1" fill="none" viewBox="0 0 24 24" stroke="currentColor">
                   <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M9 5l7 7-7 7" />
                 </svg>
               </div>
@@ -134,15 +134,15 @@
 
             <a
               href="finances.html"
-              class="group relative flex flex-col justify-between overflow-hidden rounded-[22px] border border-white/20 bg-gradient-to-br from-amber-400/50 via-orange-300/30 to-rose-200/35 p-6 backdrop-blur-lg transition hover:-translate-y-1 hover:shadow-[0_20px_45px_-25px_rgba(251,146,60,0.8)]"
+              class="group relative flex flex-col justify-between overflow-hidden rounded-[22px] border border-white/15 bg-gradient-to-br from-amber-400/35 via-orange-300/20 to-rose-200/25 p-6 backdrop-blur-lg transition hover:-translate-y-1 hover:shadow-[0_20px_45px_-25px_rgba(251,146,60,0.6)]"
             >
               <div class="flex items-start justify-between">
-                <span class="inline-flex h-11 w-11 items-center justify-center rounded-2xl bg-white/15 text-white/95">
-                  <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                <span class="inline-flex h-12 w-12 items-center justify-center rounded-2xl bg-white/15 text-white/95">
+                  <svg xmlns="http://www.w3.org/2000/svg" class="h-6 w-6" fill="none" viewBox="0 0 24 24" stroke="currentColor">
                     <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M12 8c-1.657 0-3 .895-3 2s1.343 2 3 2 3 .895 3 2-1.343 2-3 2m0-8c1.105 0 2 .672 2 1.5S13.105 11 12 11m0-3c-1.105 0-2-.672-2-1.5S10.895 5 12 5m0 14v-2m0-10V5" />
                   </svg>
                 </span>
-                <svg class="h-5 w-5 text-white/70 transition group-hover:translate-x-1" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                <svg class="h-6 w-6 text-white/75 transition group-hover:translate-x-1" fill="none" viewBox="0 0 24 24" stroke="currentColor">
                   <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M9 5l7 7-7 7" />
                 </svg>
               </div>
@@ -151,15 +151,15 @@
 
             <a
               href="experiments.html"
-              class="group relative flex flex-col justify-between overflow-hidden rounded-[22px] border border-white/20 bg-gradient-to-br from-indigo-400/55 via-violet-400/30 to-blue-300/30 p-6 backdrop-blur-lg transition hover:-translate-y-1 hover:shadow-[0_20px_45px_-25px_rgba(99,102,241,0.8)]"
+              class="group relative flex flex-col justify-between overflow-hidden rounded-[22px] border border-white/15 bg-gradient-to-br from-indigo-400/40 via-violet-400/20 to-blue-300/25 p-6 backdrop-blur-lg transition hover:-translate-y-1 hover:shadow-[0_20px_45px_-25px_rgba(99,102,241,0.6)]"
             >
               <div class="flex items-start justify-between">
-                <span class="inline-flex h-11 w-11 items-center justify-center rounded-2xl bg-white/15 text-white/95">
-                  <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                <span class="inline-flex h-12 w-12 items-center justify-center rounded-2xl bg-white/15 text-white/95">
+                  <svg xmlns="http://www.w3.org/2000/svg" class="h-6 w-6" fill="none" viewBox="0 0 24 24" stroke="currentColor">
                     <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M4.5 3.75h15m-12 0v6.878a2.25 2.25 0 01-.659 1.591l-1.885 1.885a2.25 2.25 0 001.591 3.841h10.866a2.25 2.25 0 001.591-3.841l-1.885-1.885a2.25 2.25 0 01-.659-1.591V3.75" />
                   </svg>
                 </span>
-                <svg class="h-5 w-5 text-white/70 transition group-hover:translate-x-1" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                <svg class="h-6 w-6 text-white/75 transition group-hover:translate-x-1" fill="none" viewBox="0 0 24 24" stroke="currentColor">
                   <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M9 5l7 7-7 7" />
                 </svg>
               </div>
@@ -168,16 +168,16 @@
 
             <a
               href="human-advisor.html"
-              class="group relative flex flex-col justify-between overflow-hidden rounded-[22px] border border-white/20 bg-gradient-to-br from-rose-500/55 via-rose-400/30 to-orange-300/30 p-6 backdrop-blur-lg transition hover:-translate-y-1 hover:shadow-[0_20px_45px_-25px_rgba(244,114,182,0.85)]"
+              class="group relative flex flex-col justify-between overflow-hidden rounded-[22px] border border-white/15 bg-gradient-to-br from-rose-500/40 via-rose-400/20 to-orange-300/25 p-6 backdrop-blur-lg transition hover:-translate-y-1 hover:shadow-[0_20px_45px_-25px_rgba(244,114,182,0.65)]"
             >
               <div class="flex items-start justify-between">
-                <span class="inline-flex h-11 w-11 items-center justify-center rounded-2xl bg-white/15 text-white/95">
-                  <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                <span class="inline-flex h-12 w-12 items-center justify-center rounded-2xl bg-white/15 text-white/95">
+                  <svg xmlns="http://www.w3.org/2000/svg" class="h-6 w-6" fill="none" viewBox="0 0 24 24" stroke="currentColor">
                     <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M16 7a4 4 0 11-8 0 4 4 0 018 0z" />
                     <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M12 14a7 7 0 00-7 7h14a7 7 0 00-7-7z" />
                   </svg>
                 </span>
-                <svg class="h-5 w-5 text-white/70 transition group-hover:translate-x-1" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                <svg class="h-6 w-6 text-white/75 transition group-hover:translate-x-1" fill="none" viewBox="0 0 24 24" stroke="currentColor">
                   <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M9 5l7 7-7 7" />
                 </svg>
               </div>
@@ -186,15 +186,15 @@
 
             <a
               href="ai-companion.html"
-              class="group relative flex flex-col justify-between overflow-hidden rounded-[22px] border border-white/20 bg-gradient-to-br from-slate-100/70 via-white/40 to-blue-200/45 p-6 text-slate-900 backdrop-blur-lg transition hover:-translate-y-1 hover:shadow-[0_20px_45px_-25px_rgba(148,163,184,0.8)]"
+              class="group relative flex flex-col justify-between overflow-hidden rounded-[22px] border border-white/15 bg-gradient-to-br from-indigo-500/35 via-slate-500/20 to-blue-400/25 p-6 text-white backdrop-blur-lg transition hover:-translate-y-1 hover:shadow-[0_20px_45px_-25px_rgba(79,70,229,0.6)]"
             >
               <div class="flex items-start justify-between">
-                <span class="inline-flex h-11 w-11 items-center justify-center rounded-2xl bg-white/90 text-slate-900">
-                  <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                <span class="inline-flex h-12 w-12 items-center justify-center rounded-2xl bg-white/20 text-white">
+                  <svg xmlns="http://www.w3.org/2000/svg" class="h-6 w-6" fill="none" viewBox="0 0 24 24" stroke="currentColor">
                     <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.6" d="M12 6v6l3 3m6-3a9 9 0 11-18 0 9 9 0 0118 0z" />
                   </svg>
                 </span>
-                <svg class="h-5 w-5 text-slate-700 transition group-hover:translate-x-1" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                <svg class="h-6 w-6 text-white/75 transition group-hover:translate-x-1" fill="none" viewBox="0 0 24 24" stroke="currentColor">
                   <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M9 5l7 7-7 7" />
                 </svg>
               </div>

--- a/growth.html
+++ b/growth.html
@@ -9,7 +9,7 @@
         theme: {
           extend: {
             fontFamily: {
-              script: ['"Dancing Script"', 'cursive'],
+              script: ['"Pacifico"', '"Allura"', 'cursive'],
               sans: ['"Manrope"', 'system-ui', 'sans-serif'],
             },
             colors: {
@@ -24,7 +24,7 @@
     <script src="https://cdn.tailwindcss.com"></script>
     <link
       rel="stylesheet"
-      href="https://fonts.googleapis.com/css2?family=Dancing+Script:wght@500;600&family=Manrope:wght@400;500;600;700&display=swap"
+      href="https://fonts.googleapis.com/css2?family=Allura&family=Manrope:wght@400;500;600;700&family=Pacifico&display=swap"
     />
     <style>
       body {
@@ -46,7 +46,7 @@
               <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M15 19l-7-7 7-7" />
             </svg>
           </button>
-          <div class="text-4xl font-script leading-none text-white">genie</div>
+          <div class="text-4xl font-script leading-none text-white tracking-wide">genie</div>
         </div>
         <div class="text-right">
           <p class="text-sm text-white/70">Your AI business advisor</p>
@@ -56,119 +56,154 @@
       <main class="flex-1 py-10 flex flex-col gap-12">
         <section class="max-w-4xl">
           <h1 class="text-5xl md:text-6xl font-light">Growth</h1>
-          <p class="mt-3 text-base text-white/70">Momentum view of covers, delivery, and pipeline.</p>
+          <p class="mt-3 text-base text-white/70">Momentum across acquisition, conversion, and retention.</p>
         </section>
 
-        <section class="rounded-[32px] border border-outline/60 bg-surface backdrop-blur-xl p-8 space-y-8">
+        <section class="space-y-12">
           <div class="flex flex-wrap items-center justify-between gap-4">
-            <div class="inline-flex rounded-full bg-white/10 p-1 text-sm">
+            <div class="inline-flex rounded-full bg-white/5 p-1 text-sm">
               <button class="tab-trigger rounded-full px-4 py-2 font-medium bg-white text-black" data-target="growth-strategy">
                 Strategy
               </button>
-              <button class="tab-trigger rounded-full px-4 py-2 font-medium text-white/70 hover:text-white transition" data-target="growth-stats">
-                Stats
+              <button class="tab-trigger rounded-full px-4 py-2 font-medium text-white/70 hover:text-white transition" data-target="growth-dashboard">
+                Dashboard
               </button>
             </div>
             <span class="text-sm text-white/60">Updated · moments ago</span>
           </div>
 
-          <div id="growth-strategy" class="tab-panel space-y-8">
-            <div class="relative rounded-[28px] border border-outline bg-white/5 p-8">
-              <div class="flex items-start justify-between gap-6">
+          <div id="growth-strategy" class="tab-panel space-y-12">
+            <div class="space-y-6">
+              <div class="flex flex-wrap items-start justify-between gap-6">
                 <div>
-                  <h2 class="text-2xl font-semibold">MECE pipeline map</h2>
-                  <p class="mt-2 text-white/70 max-w-xl">
-                    Breaking growth into acquisition, conversion, retention, and expansion lets us spot gaps instantly. Genie keeps these lanes balanced with the latest signals.
-                  </p>
+                  <h2 class="text-2xl font-semibold">Strategy</h2>
+                  <p class="mt-2 text-white/65 max-w-xl">Keep the pipeline balanced with the freshest demand signals.</p>
                 </div>
-                <div class="relative">
-                  <button
-                    id="growth-ai-button"
-                    class="inline-flex items-center gap-2 rounded-full bg-rose-500 px-4 py-2 text-sm font-semibold shadow-lg hover:bg-rose-400 transition"
-                    type="button"
-                  >
-                    <span class="inline-block h-2 w-2 rounded-full bg-white animate-pulse"></span>
-                    AI suggestion
-                  </button>
-                  <div
-                    id="growth-ai-menu"
-                    class="absolute right-0 mt-3 hidden w-48 rounded-2xl border border-white/20 bg-night/95 p-3 text-sm shadow-2xl"
-                  >
-                    <button class="menu-option flex w-full items-center gap-2 rounded-xl px-3 py-2 text-left text-white/80 hover:bg-white/10" data-action="change">
-                      <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.6" d="M4 7h16M4 12h12m-6 5h6" />
-                      </svg>
-                      Change plan
-                    </button>
-                    <button class="menu-option flex w-full items-center gap-2 rounded-xl px-3 py-2 text-left text-white/80 hover:bg-white/10" data-action="experiment">
-                      <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.6" d="M12 6v12m6-6H6" />
-                      </svg>
-                      Add to experiment
-                    </button>
-                  </div>
-                </div>
+                <button
+                  type="button"
+                  class="growth-ai-trigger inline-flex items-center gap-2 rounded-full bg-emerald-500 px-4 py-2 text-sm font-semibold shadow-lg hover:bg-emerald-400 transition"
+                  data-label="Strategy overview"
+                >
+                  <span class="inline-block h-2 w-2 rounded-full bg-white animate-pulse"></span>
+                  AI suggestion
+                </button>
               </div>
 
-              <div class="mt-8 grid gap-6 md:grid-cols-2 xl:grid-cols-4">
-                <div class="rounded-3xl bg-gradient-to-br from-emerald-400/35 via-emerald-400/15 to-transparent p-6">
-                  <p class="text-sm font-semibold text-white/80">Acquisition</p>
-                  <ul class="mt-4 space-y-3 text-sm text-white/70">
-                    <li>Chef counter livestream draws 180 viewers</li>
-                    <li>DoorDash bundles promoted after 8pm</li>
-                    <li>Campus flyering with QR codes</li>
+              <div class="grid gap-6 md:grid-cols-2 xl:grid-cols-4">
+                <div class="relative rounded-3xl bg-gradient-to-br from-emerald-400/30 via-emerald-400/10 to-transparent p-6 space-y-4">
+                  <div class="flex items-start justify-between gap-3">
+                    <div>
+                      <p class="text-sm font-semibold text-white">Acquisition</p>
+                      <p class="text-xs uppercase tracking-wide text-white/50">Top of funnel</p>
+                    </div>
+                    <button
+                      type="button"
+                      class="growth-ai-trigger inline-flex items-center gap-1 rounded-full bg-white/15 px-3 py-1 text-[11px] font-medium text-white/80 hover:bg-white/25 transition"
+                      data-label="Acquisition"
+                    >
+                      <svg xmlns="http://www.w3.org/2000/svg" class="h-3.5 w-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M12 3v3m0 12v3m9-9h-3M6 12H3m15.364 6.364-2.121-2.121M8.757 8.757 6.636 6.636m12.728 0-2.121 2.121M8.757 15.243l-2.121 2.121" />
+                      </svg>
+                      Genie tip
+                    </button>
+                  </div>
+                  <ul class="space-y-3 text-sm text-white/75">
+                    <li>Chef counter livestream retargeting pushes 180 warm viewers into SMS.</li>
+                    <li>DoorDash bundles feature "study break" upsell after 8:30p.</li>
                   </ul>
                 </div>
-                <div class="rounded-3xl bg-gradient-to-br from-cyan-400/35 via-cyan-400/15 to-transparent p-6">
-                  <p class="text-sm font-semibold text-white/80">Conversion</p>
-                  <ul class="mt-4 space-y-3 text-sm text-white/70">
-                    <li>Two-tap waitlist with upsell suggestions</li>
-                    <li>Tablets stationed at grab-and-go queue</li>
-                    <li>Chef stories displayed on in-store screens</li>
+                <div class="relative rounded-3xl bg-gradient-to-br from-cyan-400/30 via-cyan-400/10 to-transparent p-6 space-y-4">
+                  <div class="flex items-start justify-between gap-3">
+                    <div>
+                      <p class="text-sm font-semibold text-white">Conversion</p>
+                      <p class="text-xs uppercase tracking-wide text-white/50">On-premise</p>
+                    </div>
+                    <button
+                      type="button"
+                      class="growth-ai-trigger inline-flex items-center gap-1 rounded-full bg-white/15 px-3 py-1 text-[11px] font-medium text-white/80 hover:bg-white/25 transition"
+                      data-label="Conversion"
+                    >
+                      <svg xmlns="http://www.w3.org/2000/svg" class="h-3.5 w-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M12 3v3m0 12v3m9-9h-3M6 12H3m15.364 6.364-2.121-2.121M8.757 8.757 6.636 6.636m12.728 0-2.121 2.121M8.757 15.243l-2.121 2.121" />
+                      </svg>
+                      Genie tip
+                    </button>
+                  </div>
+                  <ul class="space-y-3 text-sm text-white/75">
+                    <li>Two-tap waitlist upsell shows chef specials when queue > 20 minutes.</li>
+                    <li>Tablets prompt add-ons when guests scan QR for midnight dessert.</li>
                   </ul>
                 </div>
-                <div class="rounded-3xl bg-gradient-to-br from-violet-400/35 via-violet-400/15 to-transparent p-6">
-                  <p class="text-sm font-semibold text-white/80">Retention</p>
-                  <ul class="mt-4 space-y-3 text-sm text-white/70">
-                    <li>Loyalty SMS prompts 72-hour return visit</li>
-                    <li>Personalized "family meal" follow-ups</li>
-                    <li>Chef Bee check-in DM every Friday</li>
+                <div class="relative rounded-3xl bg-gradient-to-br from-violet-400/30 via-violet-400/10 to-transparent p-6 space-y-4">
+                  <div class="flex items-start justify-between gap-3">
+                    <div>
+                      <p class="text-sm font-semibold text-white">Retention</p>
+                      <p class="text-xs uppercase tracking-wide text-white/50">Return visits</p>
+                    </div>
+                    <button
+                      type="button"
+                      class="growth-ai-trigger inline-flex items-center gap-1 rounded-full bg-white/15 px-3 py-1 text-[11px] font-medium text-white/80 hover:bg-white/25 transition"
+                      data-label="Retention"
+                    >
+                      <svg xmlns="http://www.w3.org/2000/svg" class="h-3.5 w-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M12 3v3m0 12v3m9-9h-3M6 12H3m15.364 6.364-2.121-2.121M8.757 8.757 6.636 6.636m12.728 0-2.121 2.121M8.757 15.243l-2.121 2.121" />
+                      </svg>
+                      Genie tip
+                    </button>
+                  </div>
+                  <ul class="space-y-3 text-sm text-white/75">
+                    <li>Loyalty SMS triggers 72-hour bounceback with "bring a friend" reward.</li>
+                    <li>Personalized DM check-ins from Chef Bee every Friday afternoon.</li>
                   </ul>
                 </div>
-                <div class="rounded-3xl bg-gradient-to-br from-amber-400/35 via-amber-400/15 to-transparent p-6">
-                  <p class="text-sm font-semibold text-white/80">Expansion</p>
-                  <ul class="mt-4 space-y-3 text-sm text-white/70">
-                    <li>Catering sampler runs to downtown offices</li>
-                    <li>Night market pop-up with merch booth</li>
-                    <li>Partnership pipeline with UW clubs</li>
+                <div class="relative rounded-3xl bg-gradient-to-br from-amber-400/30 via-amber-400/10 to-transparent p-6 space-y-4">
+                  <div class="flex items-start justify-between gap-3">
+                    <div>
+                      <p class="text-sm font-semibold text-white">Expansion</p>
+                      <p class="text-xs uppercase tracking-wide text-white/50">New lanes</p>
+                    </div>
+                    <button
+                      type="button"
+                      class="growth-ai-trigger inline-flex items-center gap-1 rounded-full bg-white/15 px-3 py-1 text-[11px] font-medium text-white/80 hover:bg-white/25 transition"
+                      data-label="Expansion"
+                    >
+                      <svg xmlns="http://www.w3.org/2000/svg" class="h-3.5 w-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M12 3v3m0 12v3m9-9h-3M6 12H3m15.364 6.364-2.121-2.121M8.757 8.757 6.636 6.636m12.728 0-2.121 2.121M8.757 15.243l-2.121 2.121" />
+                      </svg>
+                      Genie tip
+                    </button>
+                  </div>
+                  <ul class="space-y-3 text-sm text-white/75">
+                    <li>Night Market pop-up queue with live ordering kiosk test.</li>
+                    <li>Corporate catering sampler drops to tech offices on Tuesdays.</li>
                   </ul>
                 </div>
               </div>
             </div>
 
             <div class="grid gap-6 lg:grid-cols-[1.1fr,0.9fr]">
-              <div class="rounded-[28px] border border-outline bg-white/5 p-7 space-y-6">
+              <div class="rounded-3xl bg-white/10 p-7 backdrop-blur-sm space-y-6">
                 <div class="flex items-center justify-between">
                   <h3 class="text-xl font-semibold">Plays in motion</h3>
                   <span class="text-sm text-white/60">Live + scheduled</span>
                 </div>
                 <div class="grid gap-4 sm:grid-cols-2 text-sm text-white/80">
-                  <div class="rounded-2xl bg-gradient-to-br from-emerald-400/30 via-emerald-400/10 to-transparent p-5">
+                  <div class="rounded-2xl bg-emerald-400/15 p-5">
                     <p class="text-xs uppercase tracking-wide text-white/60">This week</p>
                     <p class="mt-3 text-lg font-semibold">Chef counter livestream</p>
                     <p class="mt-2 text-white/60">Target: 25 bookings</p>
                   </div>
-                  <div class="rounded-2xl bg-gradient-to-br from-cyan-400/30 via-cyan-400/10 to-transparent p-5">
+                  <div class="rounded-2xl bg-cyan-400/15 p-5">
                     <p class="text-xs uppercase tracking-wide text-white/60">Next</p>
                     <p class="mt-3 text-lg font-semibold">UW finals comfort tour</p>
                     <p class="mt-2 text-white/60">Covers goal: 320</p>
                   </div>
-                  <div class="rounded-2xl bg-gradient-to-br from-violet-400/30 via-violet-400/10 to-transparent p-5">
+                  <div class="rounded-2xl bg-violet-400/15 p-5">
                     <p class="text-xs uppercase tracking-wide text-white/60">Testing</p>
                     <p class="mt-3 text-lg font-semibold">Night market pre-orders</p>
                     <p class="mt-2 text-white/60">40 orders to greenlight</p>
                   </div>
-                  <div class="rounded-2xl bg-gradient-to-br from-amber-400/30 via-amber-400/10 to-transparent p-5">
+                  <div class="rounded-2xl bg-amber-400/20 p-5">
                     <p class="text-xs uppercase tracking-wide text-white/60">Pipeline</p>
                     <p class="mt-3 text-lg font-semibold">Tech catering pilots</p>
                     <p class="mt-2 text-white/60">3 proposals pending</p>
@@ -176,10 +211,10 @@
                 </div>
               </div>
 
-              <aside class="rounded-[28px] border border-outline bg-white/5 p-7 space-y-5">
+              <aside class="rounded-3xl bg-white/10 p-7 backdrop-blur-sm space-y-5">
                 <div class="flex items-center justify-between">
-                  <h3 class="text-xl font-semibold">Growth notes</h3>
-                  <span class="inline-flex items-center gap-2 rounded-full border border-white/25 px-3 py-1 text-xs text-white/70">
+                  <h3 class="text-xl font-semibold">AI notes</h3>
+                  <span class="inline-flex items-center gap-2 rounded-full bg-white/10 px-3 py-1 text-xs text-white/70">
                     <span class="h-2 w-2 rounded-full bg-emerald-400"></span>
                     Synced
                   </span>
@@ -202,80 +237,106 @@
             </div>
           </div>
 
-          <div id="growth-stats" class="tab-panel hidden space-y-8">
-            <div class="grid gap-6 md:grid-cols-4 text-center">
-              <div class="rounded-3xl border border-outline bg-white/5 p-6">
+          <div id="growth-dashboard" class="tab-panel hidden space-y-10">
+            <div class="grid gap-6 md:grid-cols-4">
+              <div class="rounded-3xl bg-white/5 p-6 text-center shadow-[0_18px_30px_-25px_rgba(16,185,129,0.4)]">
                 <p class="text-sm text-white/60">Dining covers</p>
                 <p class="mt-3 text-3xl font-semibold">186</p>
                 <p class="mt-2 text-sm text-emerald-300">+12 vs last week</p>
               </div>
-              <div class="rounded-3xl border border-outline bg-white/5 p-6">
+              <div class="rounded-3xl bg-white/5 p-6 text-center shadow-[0_18px_30px_-25px_rgba(6,182,212,0.35)]">
                 <p class="text-sm text-white/60">Delivery rev</p>
                 <p class="mt-3 text-3xl font-semibold">$14.8k</p>
                 <p class="mt-2 text-sm text-emerald-300">+9% trailing 7d</p>
               </div>
-              <div class="rounded-3xl border border-outline bg-white/5 p-6">
+              <div class="rounded-3xl bg-white/5 p-6 text-center shadow-[0_18px_30px_-25px_rgba(129,140,248,0.35)]">
                 <p class="text-sm text-white/60">Pipeline deals</p>
                 <p class="mt-3 text-3xl font-semibold">7</p>
                 <p class="mt-2 text-sm text-emerald-300">3 near close</p>
               </div>
-              <div class="rounded-3xl border border-outline bg-white/5 p-6">
+              <div class="rounded-3xl bg-white/5 p-6 text-center shadow-[0_18px_30px_-25px_rgba(245,158,11,0.35)]">
                 <p class="text-sm text-white/60">Repeat rate</p>
                 <p class="mt-3 text-3xl font-semibold">28%</p>
                 <p class="mt-2 text-sm text-emerald-300">+4 pts MOM</p>
               </div>
             </div>
 
-            <div class="grid gap-6 lg:grid-cols-[1.1fr,0.9fr]">
-              <div class="rounded-[28px] border border-outline bg-white/5 p-7">
-                <h3 class="text-xl font-semibold">Flow lane</h3>
-                <div class="mt-6 space-y-5 text-sm text-white/75">
-                  <div class="flex items-center justify-between">
+            <div class="grid gap-6 lg:grid-cols-[1.05fr,0.95fr]">
+              <div class="rounded-3xl bg-white/10 p-7 backdrop-blur-sm space-y-6">
+                <div class="flex items-center justify-between">
+                  <h3 class="text-xl font-semibold">Flow lane</h3>
+                  <span class="text-xs text-white/60">Goal track</span>
+                </div>
+                <div class="space-y-5 text-sm text-white/75">
+                  <div class="flex items-center justify-between gap-4">
                     <div>
-                      <p class="font-semibold text-white/80">Awareness</p>
-                      <p class="text-xs text-white/60">Paid + organic blend</p>
+                      <p class="font-semibold text-white/85">Awareness</p>
+                      <p class="text-xs text-white/50">Paid + organic blend</p>
                     </div>
-                    <div class="h-2 w-28 rounded-full bg-white/15">
+                    <div class="flex-1 h-2 rounded-full bg-white/10">
                       <div class="h-2 rounded-full bg-emerald-300" style="width: 76%"></div>
                     </div>
+                    <span class="text-xs text-white/60">Target 80%</span>
                   </div>
-                  <div class="flex items-center justify-between">
+                  <div class="flex items-center justify-between gap-4">
                     <div>
-                      <p class="font-semibold text-white/80">Booking</p>
-                      <p class="text-xs text-white/60">Reservations + walk-ins</p>
+                      <p class="font-semibold text-white/85">Booking</p>
+                      <p class="text-xs text-white/50">Reservations + walk-ins</p>
                     </div>
-                    <div class="h-2 w-28 rounded-full bg-white/15">
+                    <div class="flex-1 h-2 rounded-full bg-white/10">
                       <div class="h-2 rounded-full bg-emerald-300" style="width: 62%"></div>
                     </div>
+                    <span class="text-xs text-white/60">Target 75%</span>
                   </div>
-                  <div class="flex items-center justify-between">
+                  <div class="flex items-center justify-between gap-4">
                     <div>
-                      <p class="font-semibold text-white/80">Repeat</p>
-                      <p class="text-xs text-white/60">Loyalty + SMS</p>
+                      <p class="font-semibold text-white/85">Repeat</p>
+                      <p class="text-xs text-white/50">Loyalty + SMS</p>
                     </div>
-                    <div class="h-2 w-28 rounded-full bg-white/15">
+                    <div class="flex-1 h-2 rounded-full bg-white/10">
                       <div class="h-2 rounded-full bg-emerald-300" style="width: 81%"></div>
                     </div>
+                    <span class="text-xs text-white/60">Target 85%</span>
                   </div>
+                </div>
+                <div class="rounded-2xl bg-white/10 p-5 text-sm text-white/75">
+                  <p class="font-semibold text-white">Next actions</p>
+                  <ul class="mt-3 space-y-2">
+                    <li class="flex items-start gap-2">
+                      <span class="mt-1 h-2 w-2 rounded-full bg-emerald-400"></span>
+                      Launch waitlist upsell test for 10pm rush on Thursday.
+                    </li>
+                    <li class="flex items-start gap-2">
+                      <span class="mt-1 h-2 w-2 rounded-full bg-cyan-400"></span>
+                      Nudge catering prospects with chef tasting invite follow-up.
+                    </li>
+                    <li class="flex items-start gap-2">
+                      <span class="mt-1 h-2 w-2 rounded-full bg-violet-400"></span>
+                      Pull loyalty churn list for personal outreach cadence.
+                    </li>
+                  </ul>
                 </div>
               </div>
 
-              <aside class="rounded-[28px] border border-outline bg-white/5 p-7 space-y-6">
-                <h3 class="text-xl font-semibold">Signals</h3>
+              <aside class="rounded-3xl bg-white/10 p-7 backdrop-blur-sm space-y-6">
+                <div class="flex items-center justify-between">
+                  <h3 class="text-xl font-semibold">Dashboard signals</h3>
+                  <span class="text-xs text-white/60">Ping · 5m ago</span>
+                </div>
                 <ul class="space-y-4 text-sm text-white/75">
-                  <li class="flex items-center justify-between">
+                  <li class="flex items-center justify-between gap-4">
                     <span>Late night wait time</span>
                     <span class="rounded-full bg-white/10 px-3 py-1 text-xs">7 min</span>
                   </li>
-                  <li class="flex items-center justify-between">
+                  <li class="flex items-center justify-between gap-4">
                     <span>Average check size</span>
                     <span class="rounded-full bg-white/10 px-3 py-1 text-xs">$27.40</span>
                   </li>
-                  <li class="flex items-center justify-between">
+                  <li class="flex items-center justify-between gap-4">
                     <span>Delivery bundles sold</span>
                     <span class="rounded-full bg-white/10 px-3 py-1 text-xs">64</span>
                   </li>
-                  <li class="flex items-center justify-between">
+                  <li class="flex items-center justify-between gap-4">
                     <span>Events pipeline</span>
                     <span class="rounded-full bg-white/10 px-3 py-1 text-xs">5 warm</span>
                   </li>
@@ -287,15 +348,34 @@
       </main>
     </div>
 
+    <div id="growth-ai-menu" class="hidden fixed z-50 w-60 rounded-2xl border border-white/15 bg-[#06101a] p-4 text-sm shadow-2xl">
+      <p class="text-xs uppercase tracking-wide text-white/50">Genie focus</p>
+      <p id="growth-menu-context" class="mt-1 text-sm font-semibold text-white"></p>
+      <div class="mt-4 space-y-2">
+        <button class="growth-menu-option flex w-full items-center gap-2 rounded-xl bg-white/10 px-3 py-2 text-left text-white/80 hover:bg-white/20 transition" data-action="tune">
+          <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.6" d="M4 7h16M4 12h12m-6 5h6" />
+          </svg>
+          Tune plan
+        </button>
+        <button class="growth-menu-option flex w-full items-center gap-2 rounded-xl bg-white/10 px-3 py-2 text-left text-white/80 hover:bg-white/20 transition" data-action="experiment">
+          <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.6" d="M12 6v12m6-6H6" />
+          </svg>
+          Draft experiment
+        </button>
+      </div>
+    </div>
+
     <script>
-      const tabButtons = document.querySelectorAll('.tab-trigger');
-      const panels = document.querySelectorAll('.tab-panel');
-      tabButtons.forEach((button) => {
+      const growthTabs = document.querySelectorAll('.tab-trigger');
+      const growthPanels = document.querySelectorAll('.tab-panel');
+      growthTabs.forEach((button) => {
         button.addEventListener('click', () => {
-          tabButtons.forEach((btn) => btn.classList.remove('bg-white', 'text-black', 'text-white/70'));
+          growthTabs.forEach((btn) => btn.classList.remove('bg-white', 'text-black', 'text-white/70'));
           button.classList.add('bg-white', 'text-black');
-          tabButtons.forEach((btn) => btn !== button && btn.classList.add('text-white/70'));
-          panels.forEach((panel) => {
+          growthTabs.forEach((btn) => btn !== button && btn.classList.add('text-white/70'));
+          growthPanels.forEach((panel) => {
             if (panel.id === button.dataset.target) {
               panel.classList.remove('hidden');
             } else {
@@ -305,25 +385,53 @@
         });
       });
 
-      const aiButton = document.getElementById('growth-ai-button');
-      const aiMenu = document.getElementById('growth-ai-menu');
-      aiButton?.addEventListener('click', (event) => {
-        event.stopPropagation();
-        aiMenu.classList.toggle('hidden');
+      const growthMenu = document.getElementById('growth-ai-menu');
+      const growthMenuContext = document.getElementById('growth-menu-context');
+      const growthTriggers = document.querySelectorAll('.growth-ai-trigger');
+      let growthActiveTrigger = null;
+
+      function positionGrowthMenu(trigger) {
+        const rect = trigger.getBoundingClientRect();
+        growthMenu.style.top = `${rect.bottom + window.scrollY + 8}px`;
+        growthMenu.style.left = `${Math.min(rect.left + window.scrollX, window.innerWidth - growthMenu.offsetWidth - 16)}px`;
+      }
+
+      growthTriggers.forEach((trigger) => {
+        trigger.addEventListener('click', (event) => {
+          event.stopPropagation();
+          const label = trigger.dataset.label || 'Strategy';
+          growthMenuContext.textContent = label;
+          growthActiveTrigger = trigger;
+          growthMenu.classList.remove('hidden');
+          growthMenu.style.display = 'block';
+          requestAnimationFrame(() => {
+            positionGrowthMenu(trigger);
+          });
+        });
       });
+
       document.addEventListener('click', (event) => {
-        if (!aiMenu.contains(event.target) && !aiButton.contains(event.target)) {
-          aiMenu.classList.add('hidden');
+        if (!growthMenu.contains(event.target)) {
+          growthMenu.classList.add('hidden');
+          growthMenu.style.display = 'none';
+          growthActiveTrigger = null;
         }
       });
 
-      const growthOptions = document.querySelectorAll('#growth-ai-menu .menu-option');
+      const growthOptions = document.querySelectorAll('.growth-menu-option');
       growthOptions.forEach((option) => {
         option.addEventListener('click', () => {
-          aiMenu.classList.add('hidden');
+          growthMenu.classList.add('hidden');
+          growthMenu.style.display = 'none';
           const action = option.dataset.action;
-          alert(action === 'change' ? 'Genie is tuning the growth plan.' : 'Experiment card drafted in Experiments.');
+          alert(action === 'tune' ? 'Genie is tuning the growth plan.' : 'Experiment card drafted in Experiments.');
         });
+      });
+
+      window.addEventListener('resize', () => {
+        if (!growthMenu.classList.contains('hidden') && growthActiveTrigger) {
+          positionGrowthMenu(growthActiveTrigger);
+        }
       });
     </script>
   </body>

--- a/human-advisor.html
+++ b/human-advisor.html
@@ -9,7 +9,7 @@
         theme: {
           extend: {
             fontFamily: {
-              script: ['"Dancing Script"', 'cursive'],
+              script: ['"Pacifico"', '"Allura"', 'cursive'],
               sans: ['"Manrope"', 'system-ui', 'sans-serif'],
             },
             colors: {
@@ -24,7 +24,7 @@
     <script src="https://cdn.tailwindcss.com"></script>
     <link
       rel="stylesheet"
-      href="https://fonts.googleapis.com/css2?family=Dancing+Script:wght@500;600&family=Manrope:wght@400;500;600;700&display=swap"
+      href="https://fonts.googleapis.com/css2?family=Allura&family=Manrope:wght@400;500;600;700&family=Pacifico&display=swap"
     />
     <style>
       body {
@@ -46,7 +46,7 @@
               <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M15 19l-7-7 7-7" />
             </svg>
           </button>
-          <div class="text-4xl font-script leading-none text-white">genie</div>
+          <div class="text-4xl font-script leading-none text-white tracking-wide">genie</div>
         </div>
         <div class="text-right">
           <p class="text-sm text-white/70">Your AI business advisor</p>
@@ -59,111 +59,133 @@
           <p class="mt-3 text-base text-white/70">Direct line to your dedicated operator — chat or hop on a call.</p>
         </section>
 
-        <section class="rounded-[32px] border border-outline/60 bg-surface backdrop-blur-xl p-8">
-          <div class="grid gap-6 lg:grid-cols-[0.95fr,1.05fr]">
-            <aside class="rounded-[28px] border border-outline bg-white/5 p-6 space-y-6">
+        <section class="grid gap-8 lg:grid-cols-[0.95fr,1.05fr]">
+          <aside class="rounded-3xl bg-gradient-to-br from-rose-500/25 via-rose-500/10 to-transparent p-8 backdrop-blur-sm shadow-[0_20px_45px_-30px_rgba(244,114,182,0.6)] space-y-8 ring-1 ring-white/10">
+            <div class="flex items-center gap-4">
+              <div class="flex h-14 w-14 items-center justify-center rounded-full bg-white/20 text-lg font-semibold text-white">MO</div>
               <div>
                 <h2 class="text-xl font-semibold">Your advisor</h2>
-                <p class="mt-2 text-sm text-white/70">Mila Ortiz · Growth partner</p>
+                <p class="mt-1 text-sm text-white/75">Mila Ortiz · Growth partner</p>
               </div>
-              <div class="space-y-4 text-sm text-white/80">
-                <div class="rounded-2xl bg-white/5 p-4">
-                  <p class="text-xs text-white/60">Mobile</p>
-                  <p class="mt-1 text-white">(206) 555-0128</p>
-                </div>
-                <div class="rounded-2xl bg-white/5 p-4">
-                  <p class="text-xs text-white/60">Email</p>
-                  <p class="mt-1 text-white">mila@suitandthai.ai</p>
-                </div>
-                <div class="rounded-2xl bg-white/5 p-4">
-                  <p class="text-xs text-white/60">Office hours</p>
-                  <p class="mt-1 text-white">Mon–Fri · 9a – 5p PT</p>
-                </div>
-              </div>
-              <div class="space-y-3 text-sm text-white/75">
-                <h3 class="text-sm font-semibold text-white/80">Upcoming</h3>
-                <div class="rounded-2xl border border-white/10 bg-white/5 p-4">
-                  <p class="text-white/80">Night Market budget review</p>
-                  <p class="text-xs text-white/50 mt-1">Today · 3:30p PT · 30 min</p>
-                </div>
-                <div class="rounded-2xl border border-white/10 bg-white/5 p-4">
-                  <p class="text-white/80">Influencer dinner recap</p>
-                  <p class="text-xs text-white/50 mt-1">Thu · 11:00a PT · 20 min</p>
-                </div>
-              </div>
-              <div class="space-y-3">
-                <h3 class="text-sm font-semibold text-white/80">Quick actions</h3>
-                <div class="grid grid-cols-2 gap-3 text-sm">
-                  <button class="rounded-2xl bg-white text-black py-2 font-semibold hover:bg-white/90 transition">Start chat</button>
-                  <button class="rounded-2xl border border-white/30 py-2 font-semibold text-white hover:border-white/60 transition">Start video call</button>
-                  <button class="col-span-2 rounded-2xl border border-white/20 py-2 font-semibold text-white/80 hover:border-white/60 transition">Send files</button>
-                </div>
-              </div>
-            </aside>
+            </div>
 
-            <div class="rounded-[28px] border border-outline bg-white/5 p-6 flex flex-col">
-              <div class="flex flex-wrap items-center justify-between gap-3 border-b border-white/10 pb-4">
-                <div>
-                  <h2 class="text-xl font-semibold">Session board</h2>
-                  <p class="text-sm text-white/60">Catch up or drop a note before the call.</p>
-                </div>
-                <div class="inline-flex items-center gap-2 rounded-full border border-white/25 px-3 py-1 text-xs text-white/70">
-                  <span class="h-2 w-2 rounded-full bg-emerald-400"></span>
-                  Mila is online
+            <div class="grid gap-4 sm:grid-cols-2 text-sm text-white/85">
+              <div class="rounded-2xl bg-white/10 p-4">
+                <p class="text-xs text-white/60">Mobile</p>
+                <p class="mt-2 text-white">(206) 555-0128</p>
+              </div>
+              <div class="rounded-2xl bg-white/10 p-4">
+                <p class="text-xs text-white/60">Email</p>
+                <p class="mt-2 text-white">mila@suitandthai.ai</p>
+              </div>
+              <div class="rounded-2xl bg-white/10 p-4 sm:col-span-2">
+                <p class="text-xs text-white/60">Office hours</p>
+                <p class="mt-2 text-white">Mon–Fri · 9a – 5p PT</p>
+              </div>
+            </div>
+
+            <div class="space-y-4 text-sm text-white/80">
+              <div class="flex items-center justify-between">
+                <h3 class="text-sm font-semibold text-white">Upcoming</h3>
+                <span class="rounded-full bg-white/15 px-3 py-1 text-xs text-white/70">Synced</span>
+              </div>
+              <div class="rounded-2xl bg-white/10 p-4">
+                <p class="text-white">Night Market budget review</p>
+                <p class="text-xs text-white/60 mt-1">Today · 3:30p PT · 30 min</p>
+              </div>
+              <div class="rounded-2xl bg-white/10 p-4">
+                <p class="text-white">Influencer dinner recap</p>
+                <p class="text-xs text-white/60 mt-1">Thu · 11:00a PT · 20 min</p>
+              </div>
+            </div>
+
+            <div class="space-y-3">
+              <h3 class="text-sm font-semibold text-white">Quick actions</h3>
+              <div class="grid grid-cols-2 gap-3 text-sm">
+                <button class="inline-flex items-center justify-center gap-2 rounded-2xl bg-white text-black px-4 py-2 font-semibold hover:bg-white/90 transition">
+                  <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M7 8h10M7 12h6m-6 4h6m8-4a9 9 0 11-18 0 9 9 0 0118 0z" />
+                  </svg>
+                  Start chat
+                </button>
+                <button class="inline-flex items-center justify-center gap-2 rounded-2xl border border-white/35 px-4 py-2 font-semibold text-white hover:border-white/60 transition">
+                  <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M15 10l4.553-2.276A1 1 0 0121 8.618v6.764a1 1 0 01-1.447.894L15 14m0-4l-4.553-2.276A1 1 0 009 8.618v6.764a1 1 0 001.447.894L15 14m0-4v4" />
+                  </svg>
+                  Video call
+                </button>
+                <button class="col-span-2 inline-flex items-center justify-center gap-2 rounded-2xl border border-white/25 px-4 py-2 font-semibold text-white/85 hover:border-white/60 transition">
+                  <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M3 7h6l2 3h10m-6 4h6m-6 4h6M3 7v13a2 2 0 002 2h12" />
+                  </svg>
+                  Send files
+                </button>
+              </div>
+            </div>
+          </aside>
+
+          <div class="rounded-3xl bg-white/10 p-6 lg:p-7 flex flex-col backdrop-blur-sm shadow-[0_20px_45px_-30px_rgba(14,165,233,0.45)] ring-1 ring-white/10">
+            <div class="flex flex-wrap items-center justify-between gap-3 border-b border-white/10 pb-4">
+              <div>
+                <h2 class="text-xl font-semibold">Session board</h2>
+                <p class="text-sm text-white/60">Catch up or drop a note before the call.</p>
+              </div>
+              <div class="inline-flex items-center gap-2 rounded-full bg-white/10 px-3 py-1 text-xs text-white/75">
+                <span class="h-2 w-2 rounded-full bg-emerald-400"></span>
+                Mila is online
+              </div>
+            </div>
+
+            <div class="flex-1 overflow-y-auto py-6 space-y-5 text-sm text-white/80">
+              <div class="space-y-2">
+                <p class="text-xs text-white/50">Yesterday · 4:12p</p>
+                <div class="max-w-xl rounded-2xl bg-white/10 px-4 py-3">
+                  Looking over Night Market staffing. Anything you want me to prep before tomorrow?
                 </div>
               </div>
-
-              <div class="flex-1 overflow-y-auto py-6 space-y-5 text-sm text-white/80">
-                <div class="space-y-2">
-                  <p class="text-xs text-white/50">Yesterday · 4:12p</p>
-                  <div class="max-w-xl rounded-2xl bg-white/10 px-4 py-3">
-                    Looking over Night Market staffing. Anything you want me to prep before tomorrow?
-                  </div>
-                </div>
-                <div class="space-y-2 text-right">
-                  <p class="text-xs text-white/50">You · 4:18p</p>
-                  <div class="ml-auto max-w-xl rounded-2xl bg-gradient-to-r from-rose-500/50 via-rose-500/20 to-white/10 px-4 py-3 text-left">
-                    Could you stress test the 10pm rush forecast and flag if we need a third POS?
-                  </div>
-                </div>
-                <div class="space-y-2">
-                  <p class="text-xs text-white/50">Today · 9:07a</p>
-                  <div class="max-w-xl rounded-2xl bg-white/10 px-4 py-3">
-                    Running numbers now — expect a note in the doc by noon. Want to add a 15-min sync?
-                  </div>
+              <div class="space-y-2 text-right">
+                <p class="text-xs text-white/50">You · 4:18p</p>
+                <div class="ml-auto max-w-xl rounded-2xl bg-gradient-to-r from-rose-500/50 via-rose-500/20 to-white/10 px-4 py-3 text-left">
+                  Could you stress test the 10pm rush forecast and flag if we need a third POS?
                 </div>
               </div>
+              <div class="space-y-2">
+                <p class="text-xs text-white/50">Today · 9:07a</p>
+                <div class="max-w-xl rounded-2xl bg-white/10 px-4 py-3">
+                  Running numbers now — expect a note in the doc by noon. Want to add a 15-min sync?
+                </div>
+              </div>
+            </div>
 
-              <form class="border-t border-white/10 pt-4 space-y-3" onsubmit="event.preventDefault();">
-                <textarea
-                  rows="3"
-                  class="w-full rounded-2xl border border-white/20 bg-transparent p-4 text-sm text-white placeholder:text-white/40 focus:border-white focus:outline-none"
-                  placeholder="Update Mila before the next call…"
-                ></textarea>
-                <div class="flex flex-wrap items-center justify-between gap-3 text-sm">
-                  <div class="flex items-center gap-2 text-white/60">
-                    <button type="button" class="inline-flex items-center gap-2 rounded-full border border-white/25 px-3 py-1 hover:border-white/60 transition">
-                      <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M15.232 5.232l3.536 3.536M9 13l6 6M4 7l5 5" />
-                      </svg>
-                      Attach
-                    </button>
-                    <button type="button" class="inline-flex items-center gap-2 rounded-full border border-white/25 px-3 py-1 hover:border-white/60 transition">
-                      <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M12 6v6l3 3" />
-                      </svg>
-                      Schedule
-                    </button>
-                  </div>
-                  <button type="submit" class="inline-flex items-center gap-2 rounded-full bg-white text-black px-5 py-2 font-semibold hover:bg-white/90 transition">
-                    Send update
+            <form class="border-t border-white/10 pt-4 space-y-3" onsubmit="event.preventDefault();">
+              <textarea
+                rows="3"
+                class="w-full rounded-2xl border border-white/20 bg-transparent p-4 text-sm text-white placeholder:text-white/40 focus:border-white focus:outline-none"
+                placeholder="Update Mila before the next call…"
+              ></textarea>
+              <div class="flex flex-wrap items-center justify-between gap-3 text-sm">
+                <div class="flex items-center gap-2 text-white/60">
+                  <button type="button" class="inline-flex items-center gap-2 rounded-full border border-white/25 px-3 py-1 hover:border-white/60 transition">
                     <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M5 12h14M12 5l7 7-7 7" />
+                      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M15.232 5.232l3.536 3.536M9 13l6 6M4 7l5 5" />
                     </svg>
+                    Attach
+                  </button>
+                  <button type="button" class="inline-flex items-center gap-2 rounded-full border border-white/25 px-3 py-1 hover:border-white/60 transition">
+                    <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M12 6v6l3 3" />
+                    </svg>
+                    Schedule
                   </button>
                 </div>
-              </form>
-            </div>
+                <button type="submit" class="inline-flex items-center gap-2 rounded-full bg-white text-black px-5 py-2 font-semibold hover:bg-white/90 transition">
+                  Send update
+                  <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M5 12h14M12 5l7 7-7 7" />
+                  </svg>
+                </button>
+              </div>
+            </form>
           </div>
         </section>
       </main>

--- a/marketing.html
+++ b/marketing.html
@@ -9,7 +9,7 @@
         theme: {
           extend: {
             fontFamily: {
-              script: ['"Dancing Script"', 'cursive'],
+              script: ['"Pacifico"', '"Allura"', 'cursive'],
               sans: ['"Manrope"', 'system-ui', 'sans-serif'],
             },
             colors: {
@@ -24,7 +24,7 @@
     <script src="https://cdn.tailwindcss.com"></script>
     <link
       rel="stylesheet"
-      href="https://fonts.googleapis.com/css2?family=Dancing+Script:wght@500;600&family=Manrope:wght@400;500;600;700&display=swap"
+      href="https://fonts.googleapis.com/css2?family=Allura&family=Manrope:wght@400;500;600;700&family=Pacifico&display=swap"
     />
     <style>
       body {
@@ -46,7 +46,7 @@
               <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M15 19l-7-7 7-7" />
             </svg>
           </button>
-          <div class="text-4xl font-script leading-none text-white">genie</div>
+          <div class="text-4xl font-script leading-none text-white tracking-wide">genie</div>
         </div>
         <div class="text-right">
           <p class="text-sm text-white/70">Your AI business advisor</p>
@@ -56,221 +56,328 @@
       <main class="flex-1 py-10 flex flex-col gap-12">
         <section class="max-w-4xl">
           <h1 class="text-5xl md:text-6xl font-light">Marketing</h1>
-          <p class="mt-3 text-base text-white/70">Strategy cockpit for Suit and Thai.</p>
+          <p class="mt-3 text-base text-white/70">Optimisze your outreach.</p>
         </section>
 
-        <section class="rounded-[32px] border border-outline/60 bg-surface backdrop-blur-xl p-8 space-y-8">
+        <section class="space-y-12">
           <div class="flex flex-wrap items-center justify-between gap-4">
-            <div class="inline-flex rounded-full bg-white/10 p-1 text-sm">
+            <div class="inline-flex rounded-full bg-white/5 p-1 text-sm">
               <button class="tab-trigger rounded-full px-4 py-2 font-medium bg-white text-black" data-target="marketing-strategy">
                 Strategy
               </button>
-              <button class="tab-trigger rounded-full px-4 py-2 font-medium text-white/70 hover:text-white transition" data-target="marketing-stats">
-                Stats
+              <button class="tab-trigger rounded-full px-4 py-2 font-medium text-white/70 hover:text-white transition" data-target="marketing-dashboard">
+                Dashboard
               </button>
             </div>
             <span class="text-sm text-white/60">Last refreshed · 3 minutes ago</span>
           </div>
 
-          <div id="marketing-strategy" class="tab-panel space-y-8">
-            <div class="relative rounded-[28px] border border-outline bg-white/5 p-8">
-              <div class="flex items-start justify-between gap-6">
+          <div id="marketing-strategy" class="tab-panel space-y-12">
+            <div class="space-y-6">
+              <div class="flex flex-wrap items-start justify-between gap-6">
                 <div>
-                  <h2 class="text-2xl font-semibold">MECE growth stack</h2>
-                  <p class="mt-2 text-white/70 max-w-xl">
-                    A one-page breakdown of every lever we are pulling across awareness, experience, community, and revenue. Each lane is mutually exclusive and collectively exhaustive so nothing slips.
+                  <h2 class="text-2xl font-semibold">Strategy</h2>
+          <p class="mt-2 text-white/65 max-w-xl">
+                    Four focused lanes to keep Suit and Thai top of mind with the right guests every day.
                   </p>
                 </div>
-                <div class="relative">
-                  <button
-                    id="marketing-ai-button"
-                    class="inline-flex items-center gap-2 rounded-full bg-rose-500 px-4 py-2 text-sm font-semibold shadow-lg hover:bg-rose-400 transition"
-                    type="button"
-                  >
-                    <span class="inline-block h-2 w-2 rounded-full bg-white animate-pulse"></span>
-                    AI suggestion
-                  </button>
-                  <div
-                    id="marketing-ai-menu"
-                    class="absolute right-0 mt-3 hidden w-48 rounded-2xl border border-white/20 bg-night/95 p-3 text-sm shadow-2xl"
-                  >
-                    <button class="menu-option flex w-full items-center gap-2 rounded-xl px-3 py-2 text-left text-white/80 hover:bg-white/10" data-action="change">
-                      <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.6" d="M4 7h16M4 12h16M4 17h10" />
-                      </svg>
-                      Change strategy
-                    </button>
-                    <button class="menu-option flex w-full items-center gap-2 rounded-xl px-3 py-2 text-left text-white/80 hover:bg-white/10" data-action="experiment">
-                      <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.6" d="M12 6v12m6-6H6" />
-                      </svg>
-                      Add to experiment
-                    </button>
-                  </div>
-                </div>
+                <button
+                  type="button"
+                  class="ai-trigger inline-flex items-center gap-2 rounded-full bg-rose-500 px-4 py-2 text-sm font-semibold shadow-lg hover:bg-rose-400 transition"
+                  data-marketing-ai="overview"
+                  data-label="Strategy overview"
+                >
+                  <span class="inline-block h-2 w-2 rounded-full bg-white animate-pulse"></span>
+                  AI suggestion
+                </button>
               </div>
 
-              <div class="mt-8 grid gap-6 md:grid-cols-2 xl:grid-cols-4">
-                <div class="rounded-3xl bg-gradient-to-br from-pink-500/35 via-pink-500/15 to-transparent p-6">
-                  <p class="text-sm font-semibold text-white/80">Awareness</p>
-                  <ul class="mt-4 space-y-3 text-sm text-white/70">
-                    <li>UW finals comfort tour reel cadence</li>
-                    <li>Paid TikTok lead-in to Chef Bee stories</li>
-                    <li>Local press seeding via Night Market angle</li>
+              <div class="grid gap-6 md:grid-cols-2 xl:grid-cols-4">
+                <div class="relative rounded-3xl bg-gradient-to-br from-fuchsia-500/25 via-fuchsia-500/10 to-transparent p-6 space-y-4">
+                  <div class="flex items-start justify-between gap-3">
+                    <div>
+                      <p class="text-sm font-semibold text-white">Social media</p>
+                      <p class="text-xs uppercase tracking-wide text-white/50">Next 7 days</p>
+                    </div>
+                    <button
+                      type="button"
+                      class="ai-trigger inline-flex items-center gap-1 rounded-full bg-white/15 px-3 py-1 text-[11px] font-medium text-white/80 hover:bg-white/25 transition"
+                      data-marketing-ai="social"
+                      data-label="Social media"
+                    >
+                      <svg xmlns="http://www.w3.org/2000/svg" class="h-3.5 w-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M12 3v3m0 12v3m9-9h-3M6 12H3m15.364 6.364l-2.121-2.121M8.757 8.757 6.636 6.636m12.728 0-2.121 2.121M8.757 15.243l-2.121 2.121" />
+                      </svg>
+                      Genie tip
+                    </button>
+                  </div>
+                  <ul class="space-y-3 text-sm text-white/75">
+                    <li>Night Market teaser reel + duet reply to top comment.</li>
+                    <li>Campus study break poll layered with finals countdown sticker.</li>
                   </ul>
                 </div>
-                <div class="rounded-3xl bg-gradient-to-br from-indigo-500/35 via-indigo-500/15 to-transparent p-6">
-                  <p class="text-sm font-semibold text-white/80">Experience</p>
-                  <ul class="mt-4 space-y-3 text-sm text-white/70">
-                    <li>Host-led queue moments with instant QR order</li>
-                    <li>Prep "comfort kits" for take-home sharing</li>
-                    <li>Chef counter livestream twice a week</li>
+                <div class="relative rounded-3xl bg-gradient-to-br from-sky-400/25 via-sky-400/10 to-transparent p-6 space-y-4">
+                  <div class="flex items-start justify-between gap-3">
+                    <div>
+                      <p class="text-sm font-semibold text-white">Community</p>
+                      <p class="text-xs uppercase tracking-wide text-white/50">Superfans</p>
+                    </div>
+                    <button
+                      type="button"
+                      class="ai-trigger inline-flex items-center gap-1 rounded-full bg-white/15 px-3 py-1 text-[11px] font-medium text-white/80 hover:bg-white/25 transition"
+                      data-marketing-ai="community"
+                      data-label="Community"
+                    >
+                      <svg xmlns="http://www.w3.org/2000/svg" class="h-3.5 w-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M12 3v3m0 12v3m9-9h-3M6 12H3m15.364 6.364l-2.121-2.121M8.757 8.757 6.636 6.636m12.728 0-2.121 2.121M8.757 15.243l-2.121 2.121" />
+                      </svg>
+                      Genie tip
+                    </button>
+                  </div>
+                  <ul class="space-y-3 text-sm text-white/75">
+                    <li>Superfan text loop with "unlock a chef story" responses.</li>
+                    <li>Discord drop: finals survival kit with live Q&A slot poll.</li>
                   </ul>
                 </div>
-                <div class="rounded-3xl bg-gradient-to-br from-emerald-500/35 via-emerald-500/15 to-transparent p-6">
-                  <p class="text-sm font-semibold text-white/80">Community</p>
-                  <ul class="mt-4 space-y-3 text-sm text-white/70">
-                    <li>Discord check-ins with top 30 superfans</li>
-                    <li>Weekly text polls with instant appetizer codes</li>
-                    <li>Student ambassador table takeover nights</li>
+                <div class="relative rounded-3xl bg-gradient-to-br from-emerald-400/25 via-emerald-400/10 to-transparent p-6 space-y-4">
+                  <div class="flex items-start justify-between gap-3">
+                    <div>
+                      <p class="text-sm font-semibold text-white">Loyalty</p>
+                      <p class="text-xs uppercase tracking-wide text-white/50">Guests on file</p>
+                    </div>
+                    <button
+                      type="button"
+                      class="ai-trigger inline-flex items-center gap-1 rounded-full bg-white/15 px-3 py-1 text-[11px] font-medium text-white/80 hover:bg-white/25 transition"
+                      data-marketing-ai="loyalty"
+                      data-label="Loyalty"
+                    >
+                      <svg xmlns="http://www.w3.org/2000/svg" class="h-3.5 w-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M12 3v3m0 12v3m9-9h-3M6 12H3m15.364 6.364l-2.121-2.121M8.757 8.757 6.636 6.636m12.728 0-2.121 2.121M8.757 15.243l-2.121 2.121" />
+                      </svg>
+                      Genie tip
+                    </button>
+                  </div>
+                  <ul class="space-y-3 text-sm text-white/75">
+                    <li>72-hour bounceback SMS with auto-loaded dessert add-on.</li>
+                    <li>Segmented email spotlighting "study buddy" table bundles.</li>
                   </ul>
                 </div>
-                <div class="rounded-3xl bg-gradient-to-br from-amber-400/40 via-amber-400/15 to-transparent p-6">
-                  <p class="text-sm font-semibold text-white/80">Revenue</p>
-                  <ul class="mt-4 space-y-3 text-sm text-white/70">
-                    <li>Bundles with Thai iced tea upsell play</li>
-                    <li>Square loyalty push for late-night crowd</li>
-                    <li>Catering sampler drops to tech offices</li>
+                <div class="relative rounded-3xl bg-gradient-to-br from-amber-400/30 via-amber-400/10 to-transparent p-6 space-y-4">
+                  <div class="flex items-start justify-between gap-3">
+                    <div>
+                      <p class="text-sm font-semibold text-white">Partnerships</p>
+                      <p class="text-xs uppercase tracking-wide text-white/50">Local reach</p>
+                    </div>
+                    <button
+                      type="button"
+                      class="ai-trigger inline-flex items-center gap-1 rounded-full bg-white/15 px-3 py-1 text-[11px] font-medium text-white/80 hover:bg-white/25 transition"
+                      data-marketing-ai="partnerships"
+                      data-label="Partnerships"
+                    >
+                      <svg xmlns="http://www.w3.org/2000/svg" class="h-3.5 w-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M12 3v3m0 12v3m9-9h-3M6 12H3m15.364 6.364l-2.121-2.121M8.757 8.757 6.636 6.636m12.728 0-2.121 2.121M8.757 15.243l-2.121 2.121" />
+                      </svg>
+                      Genie tip
+                    </button>
+                  </div>
+                  <ul class="space-y-3 text-sm text-white/75">
+                    <li>Co-host late-night cram bar with Hugo House writing center.</li>
+                    <li>Table topper swaps with Night Market vendors for cross-plug.</li>
                   </ul>
                 </div>
               </div>
             </div>
 
-            <div class="grid gap-6 lg:grid-cols-[1.1fr,0.9fr]">
-              <div class="rounded-[28px] border border-outline bg-white/5 p-7 space-y-6">
-                <div class="flex items-center justify-between">
-                  <h3 class="text-xl font-semibold">Current storylines</h3>
-                  <span class="text-sm text-white/60">Auto-tracked</span>
+            <div class="grid gap-6 lg:grid-cols-[1.15fr,0.85fr]">
+              <div class="space-y-6">
+                <div class="rounded-3xl bg-white/10 p-6 backdrop-blur-sm">
+                  <div class="flex items-center justify-between">
+                    <h3 class="text-xl font-semibold">AI insights / thoughts</h3>
+                    <span class="inline-flex items-center gap-2 rounded-full bg-white/10 px-3 py-1 text-xs text-white/70">
+                      <span class="h-2 w-2 rounded-full bg-emerald-400"></span>
+                      Synced 2m ago
+                    </span>
+                  </div>
+                  <ul class="mt-5 space-y-3 text-sm text-white/75">
+                    <li class="flex gap-3">
+                      <span class="mt-1 h-2.5 w-2.5 rounded-full bg-rose-400"></span>
+                      TikTok replies mentioning "study" correlate with +18% late-night orders — double down on finals framing this week.
+                    </li>
+                    <li class="flex gap-3">
+                      <span class="mt-1 h-2.5 w-2.5 rounded-full bg-sky-400"></span>
+                      Organic press pitches with "community kitchen" angle see 3× email opens compared to generic restaurant updates.
+                    </li>
+                    <li class="flex gap-3">
+                      <span class="mt-1 h-2.5 w-2.5 rounded-full bg-amber-400"></span>
+                      Guests redeeming QR queue offers are 42% more likely to join SMS — cue an extra bounceback for that segment.
+                    </li>
+                  </ul>
                 </div>
-                <div class="grid gap-4 sm:grid-cols-2 text-sm text-white/80">
-                  <div class="rounded-2xl bg-gradient-to-br from-fuchsia-500/25 via-fuchsia-500/10 to-transparent p-5">
-                    <p class="text-xs uppercase tracking-wide text-white/60">Now live</p>
-                    <p class="mt-3 text-lg font-semibold">Chef Bee midnight radio</p>
-                    <p class="mt-2 text-white/60">Organic reach +24% vs last week.</p>
+
+                <div class="rounded-3xl bg-white/10 p-6 backdrop-blur-sm">
+                  <div class="flex items-center justify-between">
+                    <h3 class="text-xl font-semibold">Channel board</h3>
+                    <span class="text-xs text-white/60">Week of May 13</span>
                   </div>
-                  <div class="rounded-2xl bg-gradient-to-br from-sky-400/30 via-sky-400/10 to-transparent p-5">
-                    <p class="text-xs uppercase tracking-wide text-white/60">Next</p>
-                    <p class="mt-3 text-lg font-semibold">Night Market comfort kits</p>
-                    <p class="mt-2 text-white/60">Influencer RSVPs: 11 confirmed.</p>
-                  </div>
-                  <div class="rounded-2xl bg-gradient-to-br from-emerald-400/30 via-emerald-400/10 to-transparent p-5">
-                    <p class="text-xs uppercase tracking-wide text-white/60">Testing</p>
-                    <p class="mt-3 text-lg font-semibold">TikTok duet challenge</p>
-                    <p class="mt-2 text-white/60">Goal: +15% student traffic.</p>
-                  </div>
-                  <div class="rounded-2xl bg-gradient-to-br from-amber-400/30 via-amber-400/10 to-transparent p-5">
-                    <p class="text-xs uppercase tracking-wide text-white/60">Warm up</p>
-                    <p class="mt-3 text-lg font-semibold">Chef table email series</p>
-                    <p class="mt-2 text-white/60">Segment: top 200 SMS members.</p>
+                  <div class="mt-5 grid gap-4 sm:grid-cols-2 text-sm text-white/80">
+                    <div class="rounded-2xl bg-white/10 p-5 space-y-2">
+                      <p class="text-xs uppercase tracking-wide text-white/50">Social</p>
+                      <p class="text-lg font-semibold">Midnight Market hype</p>
+                      <p class="text-white/60">Reel + duet chain, publish Wed 7p.</p>
+                    </div>
+                    <div class="rounded-2xl bg-white/10 p-5 space-y-2">
+                      <p class="text-xs uppercase tracking-wide text-white/50">Email</p>
+                      <p class="text-lg font-semibold">Study buddy bundles</p>
+                      <p class="text-white/60">Segment: loyalty tiers A/B.</p>
+                    </div>
+                    <div class="rounded-2xl bg-white/10 p-5 space-y-2">
+                      <p class="text-xs uppercase tracking-wide text-white/50">PR</p>
+                      <p class="text-lg font-semibold">Night Market preview</p>
+                      <p class="text-white/60">Media list locked · send Tue 9a.</p>
+                    </div>
+                    <div class="rounded-2xl bg-white/10 p-5 space-y-2">
+                      <p class="text-xs uppercase tracking-wide text-white/50">Community</p>
+                      <p class="text-lg font-semibold">Superfan check-in</p>
+                      <p class="text-white/60">Voice memo drop Friday noon.</p>
+                    </div>
                   </div>
                 </div>
               </div>
 
-              <aside class="rounded-[28px] border border-outline bg-white/5 p-7 space-y-5">
+              <aside class="rounded-3xl bg-white/10 p-6 space-y-5 backdrop-blur-sm">
                 <div class="flex items-center justify-between">
-                  <h3 class="text-xl font-semibold">Playbook notes</h3>
-                  <span class="inline-flex items-center gap-2 rounded-full border border-white/25 px-3 py-1 text-xs text-white/70">
-                    <span class="h-2 w-2 rounded-full bg-emerald-400"></span>
-                    Synced
-                  </span>
+                  <h3 class="text-xl font-semibold">Collab tracker</h3>
+                  <span class="text-xs text-white/60">3 active threads</span>
                 </div>
-                <ul class="space-y-3 text-sm text-white/75">
-                  <li class="flex items-start gap-3">
-                    <span class="mt-1 h-2.5 w-2.5 rounded-full bg-fuchsia-400"></span>
-                    Shift two budget points from static IG posts to Spark ads for TikTok challenge kickoff.
+                <ul class="space-y-4 text-sm text-white/75">
+                  <li class="rounded-2xl bg-white/10 p-4">
+                    <div class="flex items-center justify-between">
+                      <p class="font-semibold text-white/85">UW Esports Lounge</p>
+                      <span class="rounded-full bg-emerald-400/20 px-3 py-1 text-xs text-emerald-200">Go</span>
+                    </div>
+                    <p class="mt-2 text-white/60">Joint finals watch party · promo assets approved.</p>
                   </li>
-                  <li class="flex items-start gap-3">
-                    <span class="mt-1 h-2.5 w-2.5 rounded-full bg-sky-400"></span>
-                    Prep Canva templates for finals-themed Stories; assign to Mila by Thursday.
+                  <li class="rounded-2xl bg-white/10 p-4">
+                    <div class="flex items-center justify-between">
+                      <p class="font-semibold text-white/85">Seattle Night Market</p>
+                      <span class="rounded-full bg-amber-400/20 px-3 py-1 text-xs text-amber-200">Prep</span>
+                    </div>
+                    <p class="mt-2 text-white/60">Menu finalized, signage proof due Wednesday.</p>
                   </li>
-                  <li class="flex items-start gap-3">
-                    <span class="mt-1 h-2.5 w-2.5 rounded-full bg-amber-400"></span>
-                    Bundle UGC from ambassadors into a 30-second "why we study here" montage.
+                  <li class="rounded-2xl bg-white/10 p-4">
+                    <div class="flex items-center justify-between">
+                      <p class="font-semibold text-white/85">Chef Bee podcast</p>
+                      <span class="rounded-full bg-rose-400/20 px-3 py-1 text-xs text-rose-200">Pitch</span>
+                    </div>
+                    <p class="mt-2 text-white/60">Episode outline in draft — waiting on producer feedback.</p>
                   </li>
                 </ul>
               </aside>
             </div>
           </div>
 
-          <div id="marketing-stats" class="tab-panel hidden space-y-8">
-            <div class="grid gap-6 md:grid-cols-4 text-center">
-              <div class="rounded-3xl border border-outline bg-white/5 p-6">
-                <p class="text-sm text-white/60">Followers</p>
-                <p class="mt-3 text-3xl font-semibold">2.4k</p>
-                <p class="mt-2 text-sm text-emerald-300">+18% in 14 days</p>
+          <div id="marketing-dashboard" class="tab-panel hidden space-y-10">
+            <div class="grid gap-6 md:grid-cols-4">
+              <div class="rounded-3xl bg-white/5 p-6 text-center shadow-[0_18px_30px_-25px_rgba(244,114,182,0.45)]">
+                <p class="text-sm text-white/60">Reach lift</p>
+                <p class="mt-3 text-3xl font-semibold">+18%</p>
+                <p class="mt-2 text-sm text-emerald-300">vs last 7 days</p>
               </div>
-              <div class="rounded-3xl border border-outline bg-white/5 p-6">
-                <p class="text-sm text-white/60">Email CTR</p>
-                <p class="mt-3 text-3xl font-semibold">11.8%</p>
-                <p class="mt-2 text-sm text-emerald-300">+2.1 pts</p>
+              <div class="rounded-3xl bg-white/5 p-6 text-center shadow-[0_18px_30px_-25px_rgba(56,189,248,0.4)]">
+                <p class="text-sm text-white/60">New subscribers</p>
+                <p class="mt-3 text-3xl font-semibold">312</p>
+                <p class="mt-2 text-sm text-emerald-300">SMS + email</p>
               </div>
-              <div class="rounded-3xl border border-outline bg-white/5 p-6">
-                <p class="text-sm text-white/60">Reviews</p>
-                <p class="mt-3 text-3xl font-semibold">4.7 ★</p>
-                <p class="mt-2 text-sm text-emerald-300">41 new this month</p>
+              <div class="rounded-3xl bg-white/5 p-6 text-center shadow-[0_18px_30px_-25px_rgba(16,185,129,0.35)]">
+                <p class="text-sm text-white/60">Press momentum</p>
+                <p class="mt-3 text-3xl font-semibold">6</p>
+                <p class="mt-2 text-sm text-emerald-300">Features in flight</p>
               </div>
-              <div class="rounded-3xl border border-outline bg-white/5 p-6">
-                <p class="text-sm text-white/60">ROI</p>
-                <p class="mt-3 text-3xl font-semibold">4.2×</p>
-                <p class="mt-2 text-sm text-emerald-300">Spend $620</p>
+              <div class="rounded-3xl bg-white/5 p-6 text-center shadow-[0_18px_30px_-25px_rgba(251,191,36,0.35)]">
+                <p class="text-sm text-white/60">Promo ROI</p>
+                <p class="mt-3 text-3xl font-semibold">3.4×</p>
+                <p class="mt-2 text-sm text-emerald-300">Trailing 14d</p>
               </div>
             </div>
 
             <div class="grid gap-6 lg:grid-cols-[1.1fr,0.9fr]">
-              <div class="rounded-[28px] border border-outline bg-white/5 p-7">
-                <h3 class="text-xl font-semibold">Channel pulse</h3>
-                <div class="mt-6 grid gap-4 sm:grid-cols-2 text-sm text-white/75">
-                  <div class="rounded-2xl bg-white/5 p-5">
-                    <p class="text-sm font-semibold text-white/80">Instagram</p>
-                    <p class="mt-2 text-2xl font-semibold">+26%</p>
-                    <p class="mt-1 text-xs text-white/60">Reels saves vs baseline</p>
+              <div class="rounded-3xl bg-white/5 p-7 space-y-6">
+                <div class="flex items-center justify-between">
+                  <h3 class="text-xl font-semibold">Dashboard view</h3>
+                  <span class="text-xs text-white/60">Auto-updated hourly</span>
+                </div>
+                <div class="space-y-4 text-sm text-white/75">
+                  <div class="flex items-center justify-between gap-4">
+                    <div>
+                      <p class="font-semibold text-white/85">Organic</p>
+                      <p class="text-xs text-white/50">Reach + saves</p>
+                    </div>
+                    <div class="flex-1 h-2 rounded-full bg-white/10">
+                      <div class="h-2 rounded-full bg-fuchsia-400" style="width: 74%"></div>
+                    </div>
+                    <span class="text-xs text-white/60">Goal 80%</span>
                   </div>
-                  <div class="rounded-2xl bg-white/5 p-5">
-                    <p class="text-sm font-semibold text-white/80">Email</p>
-                    <p class="mt-2 text-2xl font-semibold">31%</p>
-                    <p class="mt-1 text-xs text-white/60">Active open rate</p>
+                  <div class="flex items-center justify-between gap-4">
+                    <div>
+                      <p class="font-semibold text-white/85">Paid</p>
+                      <p class="text-xs text-white/50">Spend vs plan</p>
+                    </div>
+                    <div class="flex-1 h-2 rounded-full bg-white/10">
+                      <div class="h-2 rounded-full bg-sky-400" style="width: 61%"></div>
+                    </div>
+                    <span class="text-xs text-white/60">Goal 70%</span>
                   </div>
-                  <div class="rounded-2xl bg-white/5 p-5">
-                    <p class="text-sm font-semibold text-white/80">Google reviews</p>
-                    <p class="mt-2 text-2xl font-semibold">+17</p>
-                    <p class="mt-1 text-xs text-white/60">Mentions of "friendly"</p>
+                  <div class="flex items-center justify-between gap-4">
+                    <div>
+                      <p class="font-semibold text-white/85">Community</p>
+                      <p class="text-xs text-white/50">DMs + replies</p>
+                    </div>
+                    <div class="flex-1 h-2 rounded-full bg-white/10">
+                      <div class="h-2 rounded-full bg-emerald-400" style="width: 88%"></div>
+                    </div>
+                    <span class="text-xs text-white/60">Goal 90%</span>
                   </div>
-                  <div class="rounded-2xl bg-white/5 p-5">
-                    <p class="text-sm font-semibold text-white/80">Influencer buzz</p>
-                    <p class="mt-2 text-2xl font-semibold">8</p>
-                    <p class="mt-1 text-xs text-white/60">Live partnerships</p>
-                  </div>
+                </div>
+                <div class="rounded-2xl bg-white/10 p-5 text-sm text-white/75">
+                  <p class="font-semibold text-white">Upcoming checks</p>
+                  <ul class="mt-3 space-y-2">
+                    <li class="flex items-start gap-2">
+                      <span class="mt-1 h-2 w-2 rounded-full bg-sky-400"></span>
+                      Refresh influencer list with finals-specific voices.
+                    </li>
+                    <li class="flex items-start gap-2">
+                      <span class="mt-1 h-2 w-2 rounded-full bg-rose-400"></span>
+                      Review CTA variants for Midnight Market landing page.
+                    </li>
+                    <li class="flex items-start gap-2">
+                      <span class="mt-1 h-2 w-2 rounded-full bg-emerald-400"></span>
+                      Tag new SMS signups with "study" interest cluster.
+                    </li>
+                  </ul>
                 </div>
               </div>
 
-              <aside class="rounded-[28px] border border-outline bg-white/5 p-7 space-y-6">
-                <h3 class="text-xl font-semibold">Week-at-a-glance</h3>
+              <aside class="rounded-3xl bg-white/5 p-7 space-y-5">
+                <div class="flex items-center justify-between">
+                  <h3 class="text-xl font-semibold">Signals</h3>
+                  <span class="text-xs text-white/60">Latest ping · 9:12p</span>
+                </div>
                 <ul class="space-y-4 text-sm text-white/75">
-                  <li class="flex items-center justify-between">
-                    <span>Mon · Finals comfort drop</span>
-                    <span class="rounded-full bg-white/10 px-3 py-1 text-xs">Stories</span>
+                  <li class="flex items-center justify-between gap-4">
+                    <span>PR mentions</span>
+                    <span class="rounded-full bg-white/10 px-3 py-1 text-xs">3 live</span>
                   </li>
-                  <li class="flex items-center justify-between">
-                    <span>Tue · TikTok duet launch</span>
-                    <span class="rounded-full bg-white/10 px-3 py-1 text-xs">Organic</span>
+                  <li class="flex items-center justify-between gap-4">
+                    <span>Influencer posts</span>
+                    <span class="rounded-full bg-white/10 px-3 py-1 text-xs">7 scheduled</span>
                   </li>
-                  <li class="flex items-center justify-between">
-                    <span>Thu · Night Market teaser</span>
-                    <span class="rounded-full bg-white/10 px-3 py-1 text-xs">Press</span>
+                  <li class="flex items-center justify-between gap-4">
+                    <span>Email CTR</span>
+                    <span class="rounded-full bg-white/10 px-3 py-1 text-xs">5.4%</span>
                   </li>
-                  <li class="flex items-center justify-between">
-                    <span>Sat · Chef livestream</span>
-                    <span class="rounded-full bg-white/10 px-3 py-1 text-xs">Live</span>
+                  <li class="flex items-center justify-between gap-4">
+                    <span>Event RSVPs</span>
+                    <span class="rounded-full bg-white/10 px-3 py-1 text-xs">42</span>
                   </li>
                 </ul>
               </aside>
@@ -280,6 +387,25 @@
       </main>
     </div>
 
+    <div id="marketing-ai-menu" class="hidden fixed z-50 w-60 rounded-2xl border border-white/15 bg-[#080912] p-4 text-sm shadow-2xl">
+      <p class="text-xs uppercase tracking-wide text-white/50">Genie focus</p>
+      <p id="marketing-menu-context" class="mt-1 text-sm font-semibold text-white"></p>
+      <div class="mt-4 space-y-2">
+        <button class="menu-option flex w-full items-center gap-2 rounded-xl bg-white/10 px-3 py-2 text-left text-white/80 hover:bg-white/20 transition" data-action="change">
+          <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.6" d="M4 7h16M4 12h16m-8 5h8" />
+          </svg>
+          Refresh plan
+        </button>
+        <button class="menu-option flex w-full items-center gap-2 rounded-xl bg-white/10 px-3 py-2 text-left text-white/80 hover:bg-white/20 transition" data-action="experiment">
+          <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.6" d="M12 6v12m6-6H6" />
+          </svg>
+          Draft experiment
+        </button>
+      </div>
+    </div>
+
     <script>
       const tabButtons = document.querySelectorAll('.tab-trigger');
       const panels = document.querySelectorAll('.tab-panel');
@@ -287,8 +413,7 @@
         button.addEventListener('click', () => {
           tabButtons.forEach((btn) => btn.classList.remove('bg-white', 'text-black', 'text-white/70'));
           button.classList.add('bg-white', 'text-black');
-          tabButtons
-            .forEach((btn) => btn !== button && btn.classList.add('text-white/70'));
+          tabButtons.forEach((btn) => btn !== button && btn.classList.add('text-white/70'));
           panels.forEach((panel) => {
             if (panel.id === button.dataset.target) {
               panel.classList.remove('hidden');
@@ -299,25 +424,53 @@
         });
       });
 
-      const aiButton = document.getElementById('marketing-ai-button');
-      const aiMenu = document.getElementById('marketing-ai-menu');
-      aiButton?.addEventListener('click', (event) => {
-        event.stopPropagation();
-        aiMenu.classList.toggle('hidden');
+      const marketingMenu = document.getElementById('marketing-ai-menu');
+      const marketingContext = document.getElementById('marketing-menu-context');
+      const marketingTriggers = document.querySelectorAll('.ai-trigger');
+      let marketingActiveTrigger = null;
+
+      function positionMenu(trigger) {
+        const rect = trigger.getBoundingClientRect();
+        marketingMenu.style.top = `${rect.bottom + window.scrollY + 8}px`;
+        marketingMenu.style.left = `${Math.min(rect.left + window.scrollX, window.innerWidth - marketingMenu.offsetWidth - 16)}px`;
+      }
+
+      marketingTriggers.forEach((trigger) => {
+        trigger.addEventListener('click', (event) => {
+          event.stopPropagation();
+          const label = trigger.dataset.label || 'Strategy';
+          marketingContext.textContent = label;
+          marketingActiveTrigger = trigger;
+          marketingMenu.classList.remove('hidden');
+          marketingMenu.style.display = 'block';
+          requestAnimationFrame(() => {
+            positionMenu(trigger);
+          });
+        });
       });
+
       document.addEventListener('click', (event) => {
-        if (!aiMenu.contains(event.target) && !aiButton.contains(event.target)) {
-          aiMenu.classList.add('hidden');
+        if (!marketingMenu.contains(event.target)) {
+          marketingMenu.classList.add('hidden');
+          marketingMenu.style.display = 'none';
+          marketingActiveTrigger = null;
         }
       });
 
-      const menuOptions = document.querySelectorAll('#marketing-ai-menu .menu-option');
-      menuOptions.forEach((option) => {
+      const marketingOptions = document.querySelectorAll('#marketing-ai-menu .menu-option');
+      marketingOptions.forEach((option) => {
         option.addEventListener('click', () => {
-          aiMenu.classList.add('hidden');
+          marketingMenu.classList.add('hidden');
+          marketingMenu.style.display = 'none';
           const action = option.dataset.action;
-          alert(action === 'change' ? 'Genie queued a new strategy draft.' : 'Genie added this to Experiments.');
+          alert(action === 'change' ? 'Genie is tuning the outreach plan.' : 'Experiment idea saved to Experiments.');
         });
+      });
+
+      window.addEventListener('resize', () => {
+        if (!marketingMenu.classList.contains('hidden') && marketingActiveTrigger) {
+          positionMenu(marketingActiveTrigger);
+        }
       });
     </script>
   </body>


### PR DESCRIPTION
## Summary
* Restyled the demo landing view with Pacifico/Allura branding, a single exclamation greeting, softer gradients, and larger icons across every app tile including Genie Copilot. 【F:demo.html†L11-L199】
* Reworked the Marketing, Growth, and Competitors workspaces with cleaner strategy/dashboard layouts, embedded AI tip triggers, refreshed content, and lighter cards instead of boxed rails. 【F:marketing.html†L49-L360】【F:growth.html†L49-L344】【F:competitors.html†L49-L360】
* Updated the Human Advisor and AI Companion chats to match the dark glassmorphism aesthetic, adding polished advisor details, action icons, and a consistent copilot conversation experience. 【F:human-advisor.html†L49-L188】【F:ai-companion.html†L48-L172】

## Testing
* ⚠️ Tests not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d17ed716b8832fa85606b78972ff47