### PR TITLE
Revamp demo styling and unify Genie tips

### DIFF
--- a/ai-companion.html
+++ b/ai-companion.html
@@ -45,7 +45,7 @@
             </svg>
           </button>
           <div>
-            <div class="text-4xl font-script leading-none text-white tracking-wide">genie</div>
+            <div class="text-5xl md:text-6xl font-script leading-none text-white tracking-wide">genie</div>
             <p class="text-sm text-white/65">Copilot chat</p>
           </div>
         </div>

--- a/competitors.html
+++ b/competitors.html
@@ -46,117 +46,117 @@
               <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M15 19l-7-7 7-7" />
             </svg>
           </button>
-          <div class="text-4xl font-script leading-none text-white tracking-wide">genie</div>
+          <div class="text-5xl md:text-6xl font-script leading-none text-white tracking-wide">genie</div>
         </div>
         <div class="text-right">
-          <p class="text-sm text-white/70">Your AI business advisor</p>
+          <p class="text-lg md:text-xl font-medium text-white/80">Your AI business advisor</p>
         </div>
       </header>
 
       <main class="flex-1 py-10 flex flex-col gap-12">
         <section class="max-w-4xl">
           <h1 class="text-5xl md:text-6xl font-light">Competitors</h1>
-          <p class="mt-3 text-base text-white/70">Clean snapshot of who is moving and where we can outplay.</p>
+          <p class="mt-3 text-lg text-white/70">Clean snapshot of who is moving and where we can outplay.</p>
         </section>
 
         <section class="space-y-12">
           <div class="grid gap-6 md:grid-cols-2 xl:grid-cols-4">
-            <article class="rounded-3xl bg-white/10 p-6 shadow-[0_20px_35px_-25px_rgba(59,130,246,0.55)] space-y-5">
+            <article class="rounded-3xl bg-white/10 p-7 shadow-[0_20px_35px_-25px_rgba(59,130,246,0.55)] space-y-5">
               <div class="flex items-center justify-between">
                 <h3 class="text-xl font-semibold">Thai Tom</h3>
-                <span class="rounded-full bg-white/15 px-3 py-1 text-xs text-white/80">4.6 ★</span>
+                <span class="rounded-full bg-white/15 px-3 py-1 text-sm text-white/80">4.6 ★</span>
               </div>
-              <p class="text-sm text-white/70">Iconic counter spot with cult lines. Night menu drop drove +9% buzz.</p>
-              <ul class="space-y-2 text-sm text-white/75">
+              <p class="text-base text-white/70">Iconic counter spot with cult lines. Night menu drop drove +9% buzz.</p>
+              <ul class="space-y-2 text-base text-white/80">
                 <li class="flex items-center justify-between">
                   <span>Wait time</span>
-                  <span class="rounded-full bg-white/10 px-3 py-1 text-xs">30 min</span>
+                  <span class="rounded-full bg-white/10 px-3 py-1 text-sm">30 min</span>
                 </li>
                 <li class="flex items-center justify-between">
                   <span>Avg check</span>
-                  <span class="rounded-full bg-white/10 px-3 py-1 text-xs">$19</span>
+                  <span class="rounded-full bg-white/10 px-3 py-1 text-sm">$19</span>
                 </li>
                 <li class="flex items-center justify-between">
                   <span>Signature play</span>
-                  <span class="rounded-full bg-white/10 px-3 py-1 text-xs">Late-night wok show</span>
+                  <span class="rounded-full bg-white/10 px-3 py-1 text-sm">Late-night wok show</span>
                 </li>
               </ul>
             </article>
-            <article class="rounded-3xl bg-white/10 p-6 shadow-[0_20px_35px_-25px_rgba(147,197,253,0.5)] space-y-5">
+            <article class="rounded-3xl bg-white/10 p-7 shadow-[0_20px_35px_-25px_rgba(147,197,253,0.5)] space-y-5">
               <div class="flex items-center justify-between">
                 <h3 class="text-xl font-semibold">Pinto Bistro</h3>
-                <span class="rounded-full bg-white/15 px-3 py-1 text-xs text-white/80">4.4 ★</span>
+                <span class="rounded-full bg-white/15 px-3 py-1 text-sm text-white/80">4.4 ★</span>
               </div>
-              <p class="text-sm text-white/70">Neighborhood favorite leaning into PR. Brunch collabs fueling awareness.</p>
-              <ul class="space-y-2 text-sm text-white/75">
+              <p class="text-base text-white/70">Neighborhood favorite leaning into PR. Brunch collabs fueling awareness.</p>
+              <ul class="space-y-2 text-base text-white/80">
                 <li class="flex items-center justify-between">
                   <span>Wait time</span>
-                  <span class="rounded-full bg-white/10 px-3 py-1 text-xs">15 min</span>
+                  <span class="rounded-full bg-white/10 px-3 py-1 text-sm">15 min</span>
                 </li>
                 <li class="flex items-center justify-between">
                   <span>Avg check</span>
-                  <span class="rounded-full bg-white/10 px-3 py-1 text-xs">$24</span>
+                  <span class="rounded-full bg-white/10 px-3 py-1 text-sm">$24</span>
                 </li>
                 <li class="flex items-center justify-between">
                   <span>Signature play</span>
-                  <span class="rounded-full bg-white/10 px-3 py-1 text-xs">Chef tasting nights</span>
+                  <span class="rounded-full bg-white/10 px-3 py-1 text-sm">Chef tasting nights</span>
                 </li>
               </ul>
             </article>
-            <article class="rounded-3xl bg-white/10 p-6 shadow-[0_20px_35px_-25px_rgba(167,139,250,0.5)] space-y-5">
+            <article class="rounded-3xl bg-white/10 p-7 shadow-[0_20px_35px_-25px_rgba(167,139,250,0.5)] space-y-5">
               <div class="flex items-center justify-between">
                 <h3 class="text-xl font-semibold">Lanna House</h3>
-                <span class="rounded-full bg-white/15 px-3 py-1 text-xs text-white/80">4.7 ★</span>
+                <span class="rounded-full bg-white/15 px-3 py-1 text-sm text-white/80">4.7 ★</span>
               </div>
-              <p class="text-sm text-white/70">Elevated dining with patio expansion. Influencer dinner series launching.</p>
-              <ul class="space-y-2 text-sm text-white/75">
+              <p class="text-base text-white/70">Elevated dining with patio expansion. Influencer dinner series launching.</p>
+              <ul class="space-y-2 text-base text-white/80">
                 <li class="flex items-center justify-between">
                   <span>Wait time</span>
-                  <span class="rounded-full bg-white/10 px-3 py-1 text-xs">20 min</span>
+                  <span class="rounded-full bg-white/10 px-3 py-1 text-sm">20 min</span>
                 </li>
                 <li class="flex items-center justify-between">
                   <span>Avg check</span>
-                  <span class="rounded-full bg-white/10 px-3 py-1 text-xs">$32</span>
+                  <span class="rounded-full bg-white/10 px-3 py-1 text-sm">$32</span>
                 </li>
                 <li class="flex items-center justify-between">
                   <span>Signature play</span>
-                  <span class="rounded-full bg-white/10 px-3 py-1 text-xs">Garden patio parties</span>
+                  <span class="rounded-full bg-white/10 px-3 py-1 text-sm">Garden patio parties</span>
                 </li>
               </ul>
             </article>
-            <article class="rounded-3xl bg-white/10 p-6 shadow-[0_20px_35px_-25px_rgba(129,140,248,0.5)] space-y-5">
+            <article class="rounded-3xl bg-white/10 p-7 shadow-[0_20px_35px_-25px_rgba(129,140,248,0.5)] space-y-5">
               <div class="flex items-center justify-between">
                 <h3 class="text-xl font-semibold">Kin Khao Express</h3>
-                <span class="rounded-full bg-white/15 px-3 py-1 text-xs text-white/80">4.5 ★</span>
+                <span class="rounded-full bg-white/15 px-3 py-1 text-sm text-white/80">4.5 ★</span>
               </div>
-              <p class="text-sm text-white/70">Ghost-kitchen forward with speedy delivery. Heat-and-serve kits trending.</p>
-              <ul class="space-y-2 text-sm text-white/75">
+              <p class="text-base text-white/70">Ghost-kitchen forward with speedy delivery. Heat-and-serve kits trending.</p>
+              <ul class="space-y-2 text-base text-white/80">
                 <li class="flex items-center justify-between">
                   <span>Wait time</span>
-                  <span class="rounded-full bg-white/10 px-3 py-1 text-xs">Delivery only</span>
+                  <span class="rounded-full bg-white/10 px-3 py-1 text-sm">Delivery only</span>
                 </li>
                 <li class="flex items-center justify-between">
                   <span>Avg check</span>
-                  <span class="rounded-full bg-white/10 px-3 py-1 text-xs">$27</span>
+                  <span class="rounded-full bg-white/10 px-3 py-1 text-sm">$27</span>
                 </li>
                 <li class="flex items-center justify-between">
                   <span>Signature play</span>
-                  <span class="rounded-full bg-white/10 px-3 py-1 text-xs">Family heat kits</span>
+                  <span class="rounded-full bg-white/10 px-3 py-1 text-sm">Family heat kits</span>
                 </li>
               </ul>
             </article>
           </div>
 
           <div class="flex flex-wrap items-center justify-between gap-4">
-            <div class="inline-flex rounded-full bg-white/5 p-1 text-sm">
-              <button class="tab-trigger rounded-full px-4 py-2 font-medium bg-white text-black" data-target="competitors-strategy">
+            <div class="inline-flex rounded-full bg-white/5 p-1 text-base">
+              <button class="tab-trigger rounded-full px-5 py-2 font-semibold bg-white text-black" data-target="competitors-strategy">
                 Strategy
               </button>
-              <button class="tab-trigger rounded-full px-4 py-2 font-medium text-white/70 hover:text-white transition" data-target="competitors-dashboard">
+              <button class="tab-trigger rounded-full px-5 py-2 font-semibold text-white/75 hover:text-white transition" data-target="competitors-dashboard">
                 Dashboard
               </button>
             </div>
-            <span class="text-sm text-white/60">Listening across 38 data sources</span>
+            <span class="text-base text-white/70">Listening across 38 data sources</span>
           </div>
 
           <div id="competitors-strategy" class="tab-panel space-y-10">
@@ -167,28 +167,28 @@
               </div>
               <button
                 type="button"
-                class="competitor-ai-trigger inline-flex items-center gap-2 rounded-full bg-rose-500 px-4 py-2 text-sm font-semibold shadow-lg hover:bg-rose-400 transition"
+                class="competitor-ai-trigger inline-flex items-center gap-2 rounded-full bg-emerald-400 px-5 py-2.5 text-base font-semibold text-night shadow-lg hover:bg-emerald-300 transition"
                 data-label="Landscape overview"
               >
                 <span class="inline-block h-2 w-2 rounded-full bg-white animate-pulse"></span>
-                AI suggestion
+                Genie tip
               </button>
             </div>
 
             <div class="grid gap-6 lg:grid-cols-[1.1fr,0.9fr]">
               <div class="space-y-6">
-                <div class="rounded-3xl bg-white/10 p-6 backdrop-blur-sm space-y-5">
+                <div class="rounded-3xl bg-white/10 p-7 backdrop-blur-sm space-y-5">
                   <h3 class="text-xl font-semibold">Competitor watchlist</h3>
-                  <div class="grid gap-4 sm:grid-cols-2 text-sm text-white/80">
+                  <div class="grid gap-4 sm:grid-cols-2 text-base text-white/80">
                     <div class="rounded-2xl bg-white/10 p-4 space-y-2">
                       <div class="flex items-center justify-between">
                         <p class="font-semibold text-white">Thai Tom</p>
-                        <span class="rounded-full bg-emerald-400/20 px-3 py-1 text-xs text-emerald-200">Hot</span>
+                        <span class="rounded-full bg-emerald-400/20 px-3 py-1 text-sm text-emerald-200">Hot</span>
                       </div>
                       <p class="text-white/65">Night wok show content spiking 32% shares.</p>
                       <button
                         type="button"
-                        class="competitor-ai-trigger inline-flex items-center gap-1 rounded-full bg-white/15 px-3 py-1 text-[11px] font-medium text-white/80 hover:bg-white/25 transition"
+                        class="competitor-ai-trigger inline-flex items-center gap-2 rounded-full bg-emerald-400/90 px-3.5 py-1.5 text-xs font-semibold text-night shadow-sm hover:bg-emerald-300 transition"
                         data-label="Thai Tom"
                       >
                         <svg xmlns="http://www.w3.org/2000/svg" class="h-3.5 w-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
@@ -200,12 +200,12 @@
                     <div class="rounded-2xl bg-white/10 p-4 space-y-2">
                       <div class="flex items-center justify-between">
                         <p class="font-semibold text-white">Pinto Bistro</p>
-                        <span class="rounded-full bg-sky-400/20 px-3 py-1 text-xs text-sky-200">Watch</span>
+                        <span class="rounded-full bg-sky-400/20 px-3 py-1 text-sm text-sky-200">Watch</span>
                       </div>
                       <p class="text-white/65">Weekend brunch PR adds 11 earned hits in 14 days.</p>
                       <button
                         type="button"
-                        class="competitor-ai-trigger inline-flex items-center gap-1 rounded-full bg-white/15 px-3 py-1 text-[11px] font-medium text-white/80 hover:bg-white/25 transition"
+                        class="competitor-ai-trigger inline-flex items-center gap-2 rounded-full bg-emerald-400/90 px-3.5 py-1.5 text-xs font-semibold text-night shadow-sm hover:bg-emerald-300 transition"
                         data-label="Pinto Bistro"
                       >
                         <svg xmlns="http://www.w3.org/2000/svg" class="h-3.5 w-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
@@ -222,7 +222,7 @@
                       <p class="text-white/65">Patio expansion event series starts in 3 weeks.</p>
                       <button
                         type="button"
-                        class="competitor-ai-trigger inline-flex items-center gap-1 rounded-full bg-white/15 px-3 py-1 text-[11px] font-medium text-white/80 hover:bg-white/25 transition"
+                        class="competitor-ai-trigger inline-flex items-center gap-2 rounded-full bg-emerald-400/90 px-3.5 py-1.5 text-xs font-semibold text-night shadow-sm hover:bg-emerald-300 transition"
                         data-label="Lanna House"
                       >
                         <svg xmlns="http://www.w3.org/2000/svg" class="h-3.5 w-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
@@ -239,7 +239,7 @@
                       <p class="text-white/65">Heat-and-serve kits testing family bundle upsell.</p>
                       <button
                         type="button"
-                        class="competitor-ai-trigger inline-flex items-center gap-1 rounded-full bg-white/15 px-3 py-1 text-[11px] font-medium text-white/80 hover:bg-white/25 transition"
+                        class="competitor-ai-trigger inline-flex items-center gap-2 rounded-full bg-emerald-400/90 px-3.5 py-1.5 text-xs font-semibold text-night shadow-sm hover:bg-emerald-300 transition"
                         data-label="Kin Khao Express"
                       >
                         <svg xmlns="http://www.w3.org/2000/svg" class="h-3.5 w-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
@@ -251,9 +251,9 @@
                   </div>
                 </div>
 
-                <div class="rounded-3xl bg-white/10 p-6 backdrop-blur-sm space-y-4">
+                <div class="rounded-3xl bg-white/10 p-7 backdrop-blur-sm space-y-4">
                   <h3 class="text-xl font-semibold">AI insights / thoughts</h3>
-                  <ul class="space-y-3 text-sm text-white/75">
+                  <ul class="space-y-3 text-base text-white/80">
                     <li class="flex gap-3">
                       <span class="mt-1 h-2.5 w-2.5 rounded-full bg-rose-400"></span>
                       Thai Tom's late-night content spikes align with our own midnight orders — stack counter-programming around chef storytelling.
@@ -270,54 +270,28 @@
                 </div>
               </div>
 
-              <aside class="rounded-3xl bg-white/10 p-6 backdrop-blur-sm space-y-5">
-                <h3 class="text-xl font-semibold">Action queue</h3>
-                <ul class="space-y-4 text-sm text-white/75">
-                  <li class="rounded-2xl bg-white/10 p-4">
-                    <div class="flex items-center justify-between">
-                      <p class="font-semibold text-white">Repurpose livestream Q&A</p>
-                      <span class="rounded-full bg-emerald-400/20 px-3 py-1 text-xs text-emerald-200">Due today</span>
-                    </div>
-                    <p class="mt-2 text-white/60">Clip 3 highlights to counter Thai Tom's reel momentum.</p>
-                  </li>
-                  <li class="rounded-2xl bg-white/10 p-4">
-                    <div class="flex items-center justify-between">
-                      <p class="font-semibold text-white">Pitch finals sanctuary story</p>
-                      <span class="rounded-full bg-sky-400/20 px-3 py-1 text-xs text-sky-200">In progress</span>
-                    </div>
-                    <p class="mt-2 text-white/60">Frame around "quiet study nights" to differentiate from Pinto Bistro.</p>
-                  </li>
-                  <li class="rounded-2xl bg-white/10 p-4">
-                    <div class="flex items-center justify-between">
-                      <p class="font-semibold text-white">Catering follow-up</p>
-                      <span class="rounded-full bg-amber-400/20 px-3 py-1 text-xs text-amber-200">Tomorrow</span>
-                    </div>
-                    <p class="mt-2 text-white/60">Offer finals bundle tasting to tech offices before Kin Khao kits roll out.</p>
-                  </li>
-                </ul>
-              </aside>
             </div>
           </div>
 
           <div id="competitors-dashboard" class="tab-panel hidden space-y-10">
             <div class="grid gap-6 md:grid-cols-4">
-              <div class="rounded-3xl bg-white/5 p-6 text-center shadow-[0_18px_30px_-25px_rgba(59,130,246,0.45)]">
-                <p class="text-sm text-white/60">Search share</p>
+              <div class="rounded-3xl bg-white/5 p-7 text-center shadow-[0_18px_30px_-25px_rgba(59,130,246,0.45)]">
+                <p class="text-base text-white/70">Search share</p>
                 <p class="mt-3 text-3xl font-semibold">42%</p>
-                <p class="mt-2 text-sm text-emerald-300">Suit &amp; Thai +3%</p>
+                <p class="mt-2 text-base text-emerald-300">Suit &amp; Thai +3%</p>
               </div>
-              <div class="rounded-3xl bg-white/5 p-6 text-center shadow-[0_18px_30px_-25px_rgba(147,197,253,0.45)]">
-                <p class="text-sm text-white/60">Social buzz</p>
+              <div class="rounded-3xl bg-white/5 p-7 text-center shadow-[0_18px_30px_-25px_rgba(147,197,253,0.45)]">
+                <p class="text-base text-white/70">Social buzz</p>
                 <p class="mt-3 text-3xl font-semibold">33%</p>
-                <p class="mt-2 text-sm text-emerald-300">Chef content trending</p>
+                <p class="mt-2 text-base text-emerald-300">Chef content trending</p>
               </div>
-              <div class="rounded-3xl bg-white/5 p-6 text-center shadow-[0_18px_30px_-25px_rgba(167,139,250,0.45)]">
-                <p class="text-sm text-white/60">Press hits</p>
+              <div class="rounded-3xl bg-white/5 p-7 text-center shadow-[0_18px_30px_-25px_rgba(167,139,250,0.45)]">
+                <p class="text-base text-white/70">Press hits</p>
                 <p class="mt-3 text-3xl font-semibold">25%</p>
-                <p class="mt-2 text-sm text-emerald-300">Night Market story pending</p>
+                <p class="mt-2 text-base text-emerald-300">Night Market story pending</p>
               </div>
-              <div class="rounded-3xl bg-white/5 p-6 text-center shadow-[0_18px_30px_-25px_rgba(129,140,248,0.45)]">
-                <p class="text-sm text-white/60">Sentiment</p>
+              <div class="rounded-3xl bg-white/5 p-7 text-center shadow-[0_18px_30px_-25px_rgba(129,140,248,0.45)]">
+                <p class="text-base text-white/70">Sentiment</p>
                 <p class="mt-3 text-3xl font-semibold">4.6 ★</p>
                 <p class="mt-2 text-sm text-emerald-300">Pad kee mao keywords</p>
               </div>
@@ -329,7 +303,7 @@
                   <h3 class="text-xl font-semibold">Playbook vs rivals</h3>
                   <span class="text-xs text-white/60">Updated hourly</span>
                 </div>
-                <div class="space-y-4 text-sm text-white/75">
+                <div class="space-y-4 text-base text-white/80">
                   <div class="flex items-center justify-between gap-4">
                     <div>
                       <p class="font-semibold text-white/85">Awareness lift</p>
@@ -368,22 +342,22 @@
                   <h3 class="text-xl font-semibold">Signals</h3>
                   <span class="text-xs text-white/60">Next sweep · 45m</span>
                 </div>
-                <ul class="space-y-4 text-sm text-white/75">
+                <ul class="space-y-4 text-base text-white/80">
                   <li class="flex items-center justify-between gap-4">
                     <span>Review velocity</span>
-                    <span class="rounded-full bg-white/10 px-3 py-1 text-xs">+11 this week</span>
+                    <span class="rounded-full bg-white/10 px-3 py-1 text-sm">+11 this week</span>
                   </li>
                   <li class="flex items-center justify-between gap-4">
                     <span>Influencer chatter</span>
-                    <span class="rounded-full bg-white/10 px-3 py-1 text-xs">+7 posts</span>
+                    <span class="rounded-full bg-white/10 px-3 py-1 text-sm">+7 posts</span>
                   </li>
                   <li class="flex items-center justify-between gap-4">
                     <span>Offer overlap</span>
-                    <span class="rounded-full bg-white/10 px-3 py-1 text-xs">2 plays</span>
+                    <span class="rounded-full bg-white/10 px-3 py-1 text-sm">2 plays</span>
                   </li>
                   <li class="flex items-center justify-between gap-4">
                     <span>Price delta</span>
-                    <span class="rounded-full bg-white/10 px-3 py-1 text-xs">+$3 avg</span>
+                    <span class="rounded-full bg-white/10 px-3 py-1 text-sm">+$3 avg</span>
                   </li>
                 </ul>
               </aside>

--- a/demo.html
+++ b/demo.html
@@ -35,170 +35,170 @@
     <div class="min-h-screen flex flex-col">
       <header class="px-6 md:px-12 pt-10 flex items-start justify-between">
         <div class="flex flex-col gap-5">
-          <span class="inline-flex items-center justify-center w-11 h-11 rounded-full border border-white/25 bg-white/5 text-white/90">
+          <span class="inline-flex items-center justify-center w-12 h-12 rounded-full border border-white/25 bg-white/5 text-white/90">
             <svg
               xmlns="http://www.w3.org/2000/svg"
               viewBox="0 0 24 24"
               fill="none"
               stroke="currentColor"
               stroke-width="1.6"
-              class="w-5 h-5"
+              class="w-6 h-6"
             >
               <path stroke-linecap="round" stroke-linejoin="round" d="M3 10.5L12 4l9 6.5V20a1 1 0 01-1 1h-5.5a.5.5 0 01-.5-.5V15a2 2 0 00-2-2h-1a2 2 0 00-2 2v5.5a.5.5 0 01-.5.5H4a1 1 0 01-1-1v-9.5z" />
             </svg>
           </span>
-          <div class="text-5xl md:text-6xl font-script leading-none text-white tracking-wide">genie</div>
+          <div class="text-6xl md:text-7xl font-script leading-none text-white tracking-wide">genie</div>
         </div>
         <div class="text-right">
-          <p class="text-sm text-white/70">Your AI business advisor</p>
+          <p class="text-lg md:text-xl font-medium text-white/80">Your AI business advisor</p>
         </div>
       </header>
 
       <main class="flex-1 px-6 md:px-12 py-16">
         <section class="max-w-4xl">
           <h1 class="text-5xl md:text-6xl font-light mb-3">Hi Suit and Thai!</h1>
-          <p class="text-base text-white/70">Tap an app to dive in.</p>
+          <p class="text-lg text-white/70">Tap an app to dive in.</p>
         </section>
 
         <section class="mt-16">
           <h2 class="sr-only">Apps</h2>
-          <div class="mx-auto max-w-6xl grid gap-6 grid-cols-2 md:grid-cols-3 xl:grid-cols-4 auto-rows-[210px]">
+          <div class="mx-auto max-w-6xl grid gap-7 grid-cols-2 md:grid-cols-3 xl:grid-cols-4 auto-rows-[230px]">
             <a
               href="marketing.html"
-              class="group relative flex flex-col justify-between overflow-hidden rounded-[22px] border border-white/15 bg-gradient-to-br from-pink-400/35 via-fuchsia-400/20 to-indigo-300/25 p-6 backdrop-blur-lg transition hover:-translate-y-1 hover:shadow-[0_20px_45px_-25px_rgba(255,0,128,0.6)]"
+              class="group relative flex flex-col justify-between overflow-hidden rounded-[26px] border border-white/15 bg-gradient-to-br from-pink-400/35 via-fuchsia-400/20 to-indigo-300/25 p-7 backdrop-blur-lg transition hover:-translate-y-1 hover:shadow-[0_24px_55px_-28px_rgba(255,0,128,0.6)]"
             >
               <div class="flex items-start justify-between">
-                <span class="inline-flex h-12 w-12 items-center justify-center rounded-2xl bg-white/15 text-white/95">
-                  <svg xmlns="http://www.w3.org/2000/svg" class="h-6 w-6" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                <span class="inline-flex h-14 w-14 items-center justify-center rounded-2xl bg-white/15 text-white/95">
+                  <svg xmlns="http://www.w3.org/2000/svg" class="h-8 w-8" fill="none" viewBox="0 0 24 24" stroke="currentColor">
                     <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M12 8c-1.105 0-2 .672-2 1.5S10.895 12 12 12m0-3c1.105 0 2 .672 2 1.5S13.105 12 12 12m0 0c-1.105 0-2 .672-2 1.5S10.895 15 12 15m0-3c1.105 0 2 .672 2 1.5S13.105 15 12 15m0 3v-3m0-6V6" />
                   </svg>
                 </span>
-                <svg class="h-6 w-6 text-white/75 transition group-hover:translate-x-1" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                  <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M9 5l7 7-7 7" />
+                <svg class="h-7 w-7 text-white/75 transition group-hover:translate-x-1" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                  <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.6" d="M9 5l7 7-7 7" />
                 </svg>
               </div>
-              <h3 class="text-2xl font-semibold tracking-tight">Marketing</h3>
+              <h3 class="text-[1.75rem] font-semibold tracking-tight">Marketing</h3>
             </a>
 
             <a
               href="growth.html"
-              class="group relative flex flex-col justify-between overflow-hidden rounded-[22px] border border-white/15 bg-gradient-to-br from-emerald-400/35 via-teal-400/20 to-cyan-300/25 p-6 backdrop-blur-lg transition hover:-translate-y-1 hover:shadow-[0_20px_45px_-25px_rgba(16,185,129,0.65)]"
+              class="group relative flex flex-col justify-between overflow-hidden rounded-[26px] border border-white/15 bg-gradient-to-br from-emerald-400/35 via-teal-400/20 to-cyan-300/25 p-7 backdrop-blur-lg transition hover:-translate-y-1 hover:shadow-[0_24px_55px_-28px_rgba(16,185,129,0.65)]"
             >
               <div class="flex items-start justify-between">
-                <span class="inline-flex h-12 w-12 items-center justify-center rounded-2xl bg-white/15 text-white/95">
-                  <svg xmlns="http://www.w3.org/2000/svg" class="h-6 w-6" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                <span class="inline-flex h-14 w-14 items-center justify-center rounded-2xl bg-white/15 text-white/95">
+                  <svg xmlns="http://www.w3.org/2000/svg" class="h-8 w-8" fill="none" viewBox="0 0 24 24" stroke="currentColor">
                     <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M3 17l6-6 4 4 8-8" />
                   </svg>
                 </span>
-                <svg class="h-6 w-6 text-white/75 transition group-hover:translate-x-1" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                  <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M9 5l7 7-7 7" />
+                <svg class="h-7 w-7 text-white/75 transition group-hover:translate-x-1" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                  <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.6" d="M9 5l7 7-7 7" />
                 </svg>
               </div>
-              <h3 class="text-2xl font-semibold tracking-tight">Growth</h3>
+              <h3 class="text-[1.75rem] font-semibold tracking-tight">Growth</h3>
             </a>
 
             <a
               href="competitors.html"
-              class="group relative flex flex-col justify-between overflow-hidden rounded-[22px] border border-white/15 bg-gradient-to-br from-sky-400/35 via-blue-400/20 to-purple-300/25 p-6 backdrop-blur-lg transition hover:-translate-y-1 hover:shadow-[0_20px_45px_-25px_rgba(56,189,248,0.65)]"
+              class="group relative flex flex-col justify-between overflow-hidden rounded-[26px] border border-white/15 bg-gradient-to-br from-sky-400/35 via-blue-400/20 to-purple-300/25 p-7 backdrop-blur-lg transition hover:-translate-y-1 hover:shadow-[0_24px_55px_-28px_rgba(56,189,248,0.65)]"
             >
               <div class="flex items-start justify-between">
-                <span class="inline-flex h-12 w-12 items-center justify-center rounded-2xl bg-white/15 text-white/95">
-                  <svg xmlns="http://www.w3.org/2000/svg" class="h-6 w-6" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                <span class="inline-flex h-14 w-14 items-center justify-center rounded-2xl bg-white/15 text-white/95">
+                  <svg xmlns="http://www.w3.org/2000/svg" class="h-8 w-8" fill="none" viewBox="0 0 24 24" stroke="currentColor">
                     <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M12 6l8 4-8 4-8-4 8-4z" />
                     <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M4 14l8 4 8-4" />
                   </svg>
                 </span>
-                <svg class="h-6 w-6 text-white/75 transition group-hover:translate-x-1" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                  <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M9 5l7 7-7 7" />
+                <svg class="h-7 w-7 text-white/75 transition group-hover:translate-x-1" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                  <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.6" d="M9 5l7 7-7 7" />
                 </svg>
               </div>
-              <h3 class="text-2xl font-semibold tracking-tight">Competitors</h3>
+              <h3 class="text-[1.75rem] font-semibold tracking-tight">Competitors</h3>
             </a>
 
             <a
               href="inventory.html"
-              class="group relative flex flex-col justify-between overflow-hidden rounded-[22px] border border-white/15 bg-gradient-to-br from-orange-400/35 via-amber-300/20 to-yellow-200/25 p-6 backdrop-blur-lg transition hover:-translate-y-1 hover:shadow-[0_20px_45px_-25px_rgba(251,191,36,0.6)]"
+              class="group relative flex flex-col justify-between overflow-hidden rounded-[26px] border border-white/15 bg-gradient-to-br from-orange-400/35 via-amber-300/20 to-yellow-200/25 p-7 backdrop-blur-lg transition hover:-translate-y-1 hover:shadow-[0_24px_55px_-28px_rgba(251,191,36,0.6)]"
             >
               <div class="flex items-start justify-between">
-                <span class="inline-flex h-12 w-12 items-center justify-center rounded-2xl bg-white/15 text-white/95">
-                  <svg xmlns="http://www.w3.org/2000/svg" class="h-6 w-6" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                <span class="inline-flex h-14 w-14 items-center justify-center rounded-2xl bg-white/15 text-white/95">
+                  <svg xmlns="http://www.w3.org/2000/svg" class="h-8 w-8" fill="none" viewBox="0 0 24 24" stroke="currentColor">
                     <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M3 7h18M3 12h18M3 17h18" />
                   </svg>
                 </span>
-                <svg class="h-6 w-6 text-white/75 transition group-hover:translate-x-1" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                  <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M9 5l7 7-7 7" />
+                <svg class="h-7 w-7 text-white/75 transition group-hover:translate-x-1" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                  <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.6" d="M9 5l7 7-7 7" />
                 </svg>
               </div>
-              <h3 class="text-2xl font-semibold tracking-tight">Inventory</h3>
+              <h3 class="text-[1.75rem] font-semibold tracking-tight">Inventory</h3>
             </a>
 
             <a
               href="finances.html"
-              class="group relative flex flex-col justify-between overflow-hidden rounded-[22px] border border-white/15 bg-gradient-to-br from-amber-400/35 via-orange-300/20 to-rose-200/25 p-6 backdrop-blur-lg transition hover:-translate-y-1 hover:shadow-[0_20px_45px_-25px_rgba(251,146,60,0.6)]"
+              class="group relative flex flex-col justify-between overflow-hidden rounded-[26px] border border-white/15 bg-gradient-to-br from-amber-400/35 via-orange-300/20 to-rose-200/25 p-7 backdrop-blur-lg transition hover:-translate-y-1 hover:shadow-[0_24px_55px_-28px_rgba(251,146,60,0.6)]"
             >
               <div class="flex items-start justify-between">
-                <span class="inline-flex h-12 w-12 items-center justify-center rounded-2xl bg-white/15 text-white/95">
-                  <svg xmlns="http://www.w3.org/2000/svg" class="h-6 w-6" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                <span class="inline-flex h-14 w-14 items-center justify-center rounded-2xl bg-white/15 text-white/95">
+                  <svg xmlns="http://www.w3.org/2000/svg" class="h-8 w-8" fill="none" viewBox="0 0 24 24" stroke="currentColor">
                     <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M12 8c-1.657 0-3 .895-3 2s1.343 2 3 2 3 .895 3 2-1.343 2-3 2m0-8c1.105 0 2 .672 2 1.5S13.105 11 12 11m0-3c-1.105 0-2-.672-2-1.5S10.895 5 12 5m0 14v-2m0-10V5" />
                   </svg>
                 </span>
-                <svg class="h-6 w-6 text-white/75 transition group-hover:translate-x-1" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                  <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M9 5l7 7-7 7" />
+                <svg class="h-7 w-7 text-white/75 transition group-hover:translate-x-1" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                  <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.6" d="M9 5l7 7-7 7" />
                 </svg>
               </div>
-              <h3 class="text-2xl font-semibold tracking-tight">Finances</h3>
+              <h3 class="text-[1.75rem] font-semibold tracking-tight">Finances</h3>
             </a>
 
             <a
               href="experiments.html"
-              class="group relative flex flex-col justify-between overflow-hidden rounded-[22px] border border-white/15 bg-gradient-to-br from-indigo-400/40 via-violet-400/20 to-blue-300/25 p-6 backdrop-blur-lg transition hover:-translate-y-1 hover:shadow-[0_20px_45px_-25px_rgba(99,102,241,0.6)]"
+              class="group relative flex flex-col justify-between overflow-hidden rounded-[26px] border border-white/15 bg-gradient-to-br from-indigo-400/40 via-violet-400/20 to-blue-300/25 p-7 backdrop-blur-lg transition hover:-translate-y-1 hover:shadow-[0_24px_55px_-28px_rgba(99,102,241,0.6)]"
             >
               <div class="flex items-start justify-between">
-                <span class="inline-flex h-12 w-12 items-center justify-center rounded-2xl bg-white/15 text-white/95">
-                  <svg xmlns="http://www.w3.org/2000/svg" class="h-6 w-6" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                <span class="inline-flex h-14 w-14 items-center justify-center rounded-2xl bg-white/15 text-white/95">
+                  <svg xmlns="http://www.w3.org/2000/svg" class="h-8 w-8" fill="none" viewBox="0 0 24 24" stroke="currentColor">
                     <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M4.5 3.75h15m-12 0v6.878a2.25 2.25 0 01-.659 1.591l-1.885 1.885a2.25 2.25 0 001.591 3.841h10.866a2.25 2.25 0 001.591-3.841l-1.885-1.885a2.25 2.25 0 01-.659-1.591V3.75" />
                   </svg>
                 </span>
-                <svg class="h-6 w-6 text-white/75 transition group-hover:translate-x-1" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                  <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M9 5l7 7-7 7" />
+                <svg class="h-7 w-7 text-white/75 transition group-hover:translate-x-1" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                  <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.6" d="M9 5l7 7-7 7" />
                 </svg>
               </div>
-              <h3 class="text-2xl font-semibold tracking-tight">Experiments</h3>
+              <h3 class="text-[1.75rem] font-semibold tracking-tight">Experiments</h3>
             </a>
 
             <a
               href="human-advisor.html"
-              class="group relative flex flex-col justify-between overflow-hidden rounded-[22px] border border-white/15 bg-gradient-to-br from-rose-500/40 via-rose-400/20 to-orange-300/25 p-6 backdrop-blur-lg transition hover:-translate-y-1 hover:shadow-[0_20px_45px_-25px_rgba(244,114,182,0.65)]"
+              class="group relative flex flex-col justify-between overflow-hidden rounded-[26px] border border-white/15 bg-gradient-to-br from-rose-500/40 via-rose-400/20 to-orange-300/25 p-7 backdrop-blur-lg transition hover:-translate-y-1 hover:shadow-[0_24px_55px_-28px_rgba(244,114,182,0.65)]"
             >
               <div class="flex items-start justify-between">
-                <span class="inline-flex h-12 w-12 items-center justify-center rounded-2xl bg-white/15 text-white/95">
-                  <svg xmlns="http://www.w3.org/2000/svg" class="h-6 w-6" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                <span class="inline-flex h-14 w-14 items-center justify-center rounded-2xl bg-white/15 text-white/95">
+                  <svg xmlns="http://www.w3.org/2000/svg" class="h-8 w-8" fill="none" viewBox="0 0 24 24" stroke="currentColor">
                     <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M16 7a4 4 0 11-8 0 4 4 0 018 0z" />
                     <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M12 14a7 7 0 00-7 7h14a7 7 0 00-7-7z" />
                   </svg>
                 </span>
-                <svg class="h-6 w-6 text-white/75 transition group-hover:translate-x-1" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                  <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M9 5l7 7-7 7" />
+                <svg class="h-7 w-7 text-white/75 transition group-hover:translate-x-1" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                  <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.6" d="M9 5l7 7-7 7" />
                 </svg>
               </div>
-              <h3 class="text-2xl font-semibold tracking-tight">Human Advisor</h3>
+              <h3 class="text-[1.75rem] font-semibold tracking-tight">Human Advisor</h3>
             </a>
 
             <a
               href="ai-companion.html"
-              class="group relative flex flex-col justify-between overflow-hidden rounded-[22px] border border-white/15 bg-gradient-to-br from-indigo-500/35 via-slate-500/20 to-blue-400/25 p-6 text-white backdrop-blur-lg transition hover:-translate-y-1 hover:shadow-[0_20px_45px_-25px_rgba(79,70,229,0.6)]"
+              class="group relative flex flex-col justify-between overflow-hidden rounded-[26px] border border-white/15 bg-gradient-to-br from-indigo-500/35 via-slate-500/20 to-blue-400/25 p-7 text-white backdrop-blur-lg transition hover:-translate-y-1 hover:shadow-[0_24px_55px_-28px_rgba(79,70,229,0.6)]"
             >
               <div class="flex items-start justify-between">
-                <span class="inline-flex h-12 w-12 items-center justify-center rounded-2xl bg-white/20 text-white">
-                  <svg xmlns="http://www.w3.org/2000/svg" class="h-6 w-6" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                <span class="inline-flex h-14 w-14 items-center justify-center rounded-2xl bg-white/20 text-white">
+                  <svg xmlns="http://www.w3.org/2000/svg" class="h-8 w-8" fill="none" viewBox="0 0 24 24" stroke="currentColor">
                     <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.6" d="M12 6v6l3 3m6-3a9 9 0 11-18 0 9 9 0 0118 0z" />
                   </svg>
                 </span>
-                <svg class="h-6 w-6 text-white/75 transition group-hover:translate-x-1" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                  <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M9 5l7 7-7 7" />
+                <svg class="h-7 w-7 text-white/75 transition group-hover:translate-x-1" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                  <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.6" d="M9 5l7 7-7 7" />
                 </svg>
               </div>
-              <h3 class="text-2xl font-semibold tracking-tight">Genie Copilot</h3>
+              <h3 class="text-[1.75rem] font-semibold tracking-tight">Genie Copilot</h3>
             </a>
           </div>
         </section>

--- a/experiments.html
+++ b/experiments.html
@@ -9,7 +9,7 @@
         theme: {
           extend: {
             fontFamily: {
-              script: ['"Dancing Script"', 'cursive'],
+              script: ['"Pacifico"', '"Allura"', 'cursive'],
               sans: ['"Manrope"', 'system-ui', 'sans-serif'],
             },
             colors: {
@@ -24,7 +24,7 @@
     <script src="https://cdn.tailwindcss.com"></script>
     <link
       rel="stylesheet"
-      href="https://fonts.googleapis.com/css2?family=Dancing+Script:wght@500;600&family=Manrope:wght@400;500;600;700&display=swap"
+      href="https://fonts.googleapis.com/css2?family=Allura&family=Manrope:wght@400;500;600;700&family=Pacifico&display=swap"
     />
     <style>
       body {
@@ -50,28 +50,28 @@
               <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M15 19l-7-7 7-7" />
             </svg>
           </button>
-          <div class="text-4xl font-script leading-none text-white">genie</div>
+          <div class="text-5xl md:text-6xl font-script leading-none text-white">genie</div>
         </div>
         <div class="text-right">
-          <p class="text-sm text-white/70">Your AI business advisor</p>
+          <p class="text-lg md:text-xl font-medium text-white/80">Your AI business advisor</p>
         </div>
       </header>
 
       <main class="flex-1 py-10 flex flex-col gap-12">
         <section class="max-w-4xl">
           <h1 class="text-5xl md:text-6xl font-light">Experiments</h1>
-          <p class="mt-3 text-base text-white/70">Vertical lab of the tests we're running right now.</p>
+          <p class="mt-3 text-lg text-white/70">Vertical lab of the tests we're running right now.</p>
         </section>
 
-        <section class="rounded-[32px] border border-outline/60 bg-surface backdrop-blur-xl p-8">
+        <section class="space-y-10">
           <div class="flex flex-wrap items-center justify-between gap-4">
             <div>
               <h2 class="text-2xl font-semibold">Experiment wall</h2>
-              <p class="text-sm text-white/60">Stacked by priority · drag-ready layout coming soon</p>
+              <p class="text-base text-white/70">Stacked by priority · drag-ready layout coming soon</p>
             </div>
             <button
               id="addExperiment"
-              class="inline-flex items-center gap-2 rounded-full bg-white text-black px-4 py-2 text-sm font-semibold shadow hover:bg-white/90 transition"
+              class="inline-flex items-center gap-2 rounded-full bg-white text-black px-5 py-2 text-base font-semibold shadow hover:bg-white/90 transition"
               type="button"
             >
               <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
@@ -92,20 +92,20 @@
       role="dialog"
       aria-modal="true"
     >
-      <div class="w-full max-w-md rounded-3xl border border-outline bg-surface p-6 backdrop-blur-xl">
-        <h2 class="text-xl font-semibold">Create experiment</h2>
-        <label class="mt-4 block text-sm text-white/70">Title</label>
+      <div class="w-full max-w-md rounded-3xl border border-outline bg-surface p-7 backdrop-blur-xl">
+        <h2 class="text-2xl font-semibold">Create experiment</h2>
+        <label class="mt-4 block text-base text-white/75">Title</label>
         <input
           id="experiment-title-input"
           type="text"
-          class="mt-2 w-full rounded-2xl border border-white/20 bg-black/40 px-4 py-3 text-sm text-white focus:outline-none focus:border-white/60"
+          class="mt-2 w-full rounded-2xl border border-white/20 bg-black/40 px-4 py-3 text-base text-white focus:outline-none focus:border-white/60"
           placeholder="Give it a name"
         />
-        <div class="mt-6 flex items-center justify-end gap-3 text-sm">
+        <div class="mt-6 flex items-center justify-end gap-3 text-base">
           <button id="cancel-experiment" type="button" class="rounded-full border border-white/30 px-4 py-2 text-white hover:border-white/60 transition">
             Cancel
           </button>
-          <button id="create-experiment" type="button" class="rounded-full bg-white px-4 py-2 text-black font-semibold hover:bg-white/80 transition">
+          <button id="create-experiment" type="button" class="rounded-full bg-white px-5 py-2 text-black font-semibold hover:bg-white/80 transition">
             Create
           </button>
         </div>
@@ -113,50 +113,45 @@
     </div>
 
     <template id="experiment-template">
-      <div class="experiment-card relative overflow-hidden rounded-[28px] border border-outline bg-white/5 p-7 backdrop-blur">
+      <div class="experiment-card relative overflow-hidden rounded-[28px] border border-white/20 bg-white/10 p-8 shadow-[0_18px_45px_-30px_rgba(129,140,248,0.85)] backdrop-blur">
         <div class="flex flex-wrap items-center justify-between gap-3">
-          <h3 class="text-xl font-semibold text-white" contenteditable="true" data-placeholder="Experiment title"></h3>
-          <span class="rounded-full bg-white/10 px-3 py-1 text-xs text-white/70">Active</span>
+          <h3 class="text-2xl font-semibold text-white" contenteditable="true" data-placeholder="Experiment title"></h3>
+          <span class="rounded-full bg-white/20 px-4 py-1.5 text-sm font-medium text-night">Active</span>
         </div>
-        <div class="mt-6 grid gap-6 md:grid-cols-[minmax(0,1.2fr),auto,minmax(0,1fr)] items-start">
+        <div class="mt-7 grid gap-7 md:grid-cols-[minmax(0,1.1fr),auto,minmax(0,1fr)] items-start">
           <div class="space-y-3">
-            <p class="text-sm font-semibold text-white/70">Plan</p>
+            <p class="text-base font-semibold text-white">Plan</p>
             <div
-              class="rounded-2xl border border-white/15 bg-night/40 px-4 py-3 text-sm text-white/80"
+              class="rounded-2xl border border-white/15 bg-night/40 px-4 py-3 text-base text-white/85"
               contenteditable="true"
               data-placeholder="What are we testing?"
             ></div>
           </div>
           <div class="hidden md:flex h-full items-center justify-center">
-            <svg viewBox="0 0 120 160" class="h-32 w-20 text-white/30">
+            <svg viewBox="0 0 140 160" class="h-36 w-24 text-white/35">
               <defs>
-                <marker id="arrowhead" markerWidth="6" markerHeight="6" refX="5" refY="3" orient="auto">
+                <marker id="fork-head" markerWidth="6" markerHeight="6" refX="5" refY="3" orient="auto">
                   <polygon points="0 0, 6 3, 0 6" fill="currentColor"></polygon>
                 </marker>
               </defs>
-              <path
-                d="M10 10 C 100 30, 20 80, 95 110"
-                fill="none"
-                stroke="currentColor"
-                stroke-width="6"
-                stroke-linecap="round"
-                marker-end="url(#arrowhead)"
-              ></path>
+              <path d="M70 12v70" fill="none" stroke="currentColor" stroke-width="6" stroke-linecap="round"></path>
+              <path d="M70 80L35 130" fill="none" stroke="currentColor" stroke-width="6" stroke-linecap="round" marker-end="url(#fork-head)"></path>
+              <path d="M70 80l35 50" fill="none" stroke="currentColor" stroke-width="6" stroke-linecap="round" marker-end="url(#fork-head)"></path>
             </svg>
           </div>
           <div class="space-y-5">
             <div class="space-y-3">
-              <p class="text-sm font-semibold text-white/70">Results</p>
+              <p class="text-base font-semibold text-white">Results</p>
               <div
-                class="rounded-2xl border border-white/15 bg-night/40 px-4 py-3 text-sm text-white/80"
+                class="rounded-2xl border border-white/15 bg-night/40 px-4 py-3 text-base text-white/85"
                 contenteditable="true"
                 data-placeholder="What happened?"
               ></div>
             </div>
             <div class="space-y-3">
-              <p class="text-sm font-semibold text-white/70">Evidence</p>
+              <p class="text-base font-semibold text-white">Evidence</p>
               <div
-                class="rounded-2xl border border-white/15 bg-night/40 px-4 py-3 text-sm text-white/80"
+                class="rounded-2xl border border-white/15 bg-night/40 px-4 py-3 text-base text-white/85"
                 contenteditable="true"
                 data-placeholder="Link metrics, screenshots, notes"
               ></div>

--- a/finances.html
+++ b/finances.html
@@ -9,7 +9,7 @@
         theme: {
           extend: {
             fontFamily: {
-              script: ['"Dancing Script"', 'cursive'],
+              script: ['"Pacifico"', '"Allura"', 'cursive'],
               sans: ['"Manrope"', 'system-ui', 'sans-serif'],
             },
             colors: {
@@ -24,7 +24,7 @@
     <script src="https://cdn.tailwindcss.com"></script>
     <link
       rel="stylesheet"
-      href="https://fonts.googleapis.com/css2?family=Dancing+Script:wght@500;600&family=Manrope:wght@400;500;600;700&display=swap"
+      href="https://fonts.googleapis.com/css2?family=Allura&family=Manrope:wght@400;500;600;700&family=Pacifico&display=swap"
     />
     <style>
       body {
@@ -46,10 +46,10 @@
               <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M15 19l-7-7 7-7" />
             </svg>
           </button>
-          <div class="text-4xl font-script leading-none text-white">genie</div>
+          <div class="text-5xl md:text-6xl font-script leading-none text-white">genie</div>
         </div>
         <div class="text-right">
-          <p class="text-sm text-white/70">Your AI business advisor</p>
+          <p class="text-lg md:text-xl font-medium text-white/80">Your AI business advisor</p>
         </div>
       </header>
 

--- a/growth.html
+++ b/growth.html
@@ -46,30 +46,30 @@
               <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M15 19l-7-7 7-7" />
             </svg>
           </button>
-          <div class="text-4xl font-script leading-none text-white tracking-wide">genie</div>
+          <div class="text-5xl md:text-6xl font-script leading-none text-white tracking-wide">genie</div>
         </div>
         <div class="text-right">
-          <p class="text-sm text-white/70">Your AI business advisor</p>
+          <p class="text-lg md:text-xl font-medium text-white/80">Your AI business advisor</p>
         </div>
       </header>
 
       <main class="flex-1 py-10 flex flex-col gap-12">
         <section class="max-w-4xl">
           <h1 class="text-5xl md:text-6xl font-light">Growth</h1>
-          <p class="mt-3 text-base text-white/70">Momentum across acquisition, conversion, and retention.</p>
+          <p class="mt-3 text-lg text-white/70">Momentum across acquisition, conversion, and retention.</p>
         </section>
 
         <section class="space-y-12">
           <div class="flex flex-wrap items-center justify-between gap-4">
-            <div class="inline-flex rounded-full bg-white/5 p-1 text-sm">
-              <button class="tab-trigger rounded-full px-4 py-2 font-medium bg-white text-black" data-target="growth-strategy">
+            <div class="inline-flex rounded-full bg-white/5 p-1 text-base">
+              <button class="tab-trigger rounded-full px-5 py-2 font-semibold bg-white text-black" data-target="growth-strategy">
                 Strategy
               </button>
-              <button class="tab-trigger rounded-full px-4 py-2 font-medium text-white/70 hover:text-white transition" data-target="growth-dashboard">
+              <button class="tab-trigger rounded-full px-5 py-2 font-semibold text-white/75 hover:text-white transition" data-target="growth-dashboard">
                 Dashboard
               </button>
             </div>
-            <span class="text-sm text-white/60">Updated · moments ago</span>
+            <span class="text-base text-white/70">Updated · moments ago</span>
           </div>
 
           <div id="growth-strategy" class="tab-panel space-y-12">
@@ -77,15 +77,14 @@
               <div class="flex flex-wrap items-start justify-between gap-6">
                 <div>
                   <h2 class="text-2xl font-semibold">Strategy</h2>
-                  <p class="mt-2 text-white/65 max-w-xl">Keep the pipeline balanced with the freshest demand signals.</p>
                 </div>
                 <button
                   type="button"
-                  class="growth-ai-trigger inline-flex items-center gap-2 rounded-full bg-emerald-500 px-4 py-2 text-sm font-semibold shadow-lg hover:bg-emerald-400 transition"
+                  class="growth-ai-trigger inline-flex items-center gap-2 rounded-full bg-emerald-400 px-5 py-2.5 text-base font-semibold text-night shadow-lg hover:bg-emerald-300 transition"
                   data-label="Strategy overview"
                 >
                   <span class="inline-block h-2 w-2 rounded-full bg-white animate-pulse"></span>
-                  AI suggestion
+                  Genie tip
                 </button>
               </div>
 
@@ -93,12 +92,11 @@
                 <div class="relative rounded-3xl bg-gradient-to-br from-emerald-400/30 via-emerald-400/10 to-transparent p-6 space-y-4">
                   <div class="flex items-start justify-between gap-3">
                     <div>
-                      <p class="text-sm font-semibold text-white">Acquisition</p>
-                      <p class="text-xs uppercase tracking-wide text-white/50">Top of funnel</p>
+                      <p class="text-lg font-semibold text-white">Acquisition</p>
                     </div>
                     <button
                       type="button"
-                      class="growth-ai-trigger inline-flex items-center gap-1 rounded-full bg-white/15 px-3 py-1 text-[11px] font-medium text-white/80 hover:bg-white/25 transition"
+                      class="growth-ai-trigger inline-flex items-center gap-2 rounded-full bg-emerald-400/90 px-3.5 py-1.5 text-xs font-semibold text-night shadow-sm hover:bg-emerald-300 transition"
                       data-label="Acquisition"
                     >
                       <svg xmlns="http://www.w3.org/2000/svg" class="h-3.5 w-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
@@ -107,7 +105,7 @@
                       Genie tip
                     </button>
                   </div>
-                  <ul class="space-y-3 text-sm text-white/75">
+                  <ul class="space-y-3 text-base text-white/80">
                     <li>Chef counter livestream retargeting pushes 180 warm viewers into SMS.</li>
                     <li>DoorDash bundles feature "study break" upsell after 8:30p.</li>
                   </ul>
@@ -115,12 +113,11 @@
                 <div class="relative rounded-3xl bg-gradient-to-br from-cyan-400/30 via-cyan-400/10 to-transparent p-6 space-y-4">
                   <div class="flex items-start justify-between gap-3">
                     <div>
-                      <p class="text-sm font-semibold text-white">Conversion</p>
-                      <p class="text-xs uppercase tracking-wide text-white/50">On-premise</p>
+                      <p class="text-lg font-semibold text-white">Conversion</p>
                     </div>
                     <button
                       type="button"
-                      class="growth-ai-trigger inline-flex items-center gap-1 rounded-full bg-white/15 px-3 py-1 text-[11px] font-medium text-white/80 hover:bg-white/25 transition"
+                      class="growth-ai-trigger inline-flex items-center gap-2 rounded-full bg-emerald-400/90 px-3.5 py-1.5 text-xs font-semibold text-night shadow-sm hover:bg-emerald-300 transition"
                       data-label="Conversion"
                     >
                       <svg xmlns="http://www.w3.org/2000/svg" class="h-3.5 w-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
@@ -129,7 +126,7 @@
                       Genie tip
                     </button>
                   </div>
-                  <ul class="space-y-3 text-sm text-white/75">
+                  <ul class="space-y-3 text-base text-white/80">
                     <li>Two-tap waitlist upsell shows chef specials when queue > 20 minutes.</li>
                     <li>Tablets prompt add-ons when guests scan QR for midnight dessert.</li>
                   </ul>
@@ -137,12 +134,11 @@
                 <div class="relative rounded-3xl bg-gradient-to-br from-violet-400/30 via-violet-400/10 to-transparent p-6 space-y-4">
                   <div class="flex items-start justify-between gap-3">
                     <div>
-                      <p class="text-sm font-semibold text-white">Retention</p>
-                      <p class="text-xs uppercase tracking-wide text-white/50">Return visits</p>
+                      <p class="text-lg font-semibold text-white">Retention</p>
                     </div>
                     <button
                       type="button"
-                      class="growth-ai-trigger inline-flex items-center gap-1 rounded-full bg-white/15 px-3 py-1 text-[11px] font-medium text-white/80 hover:bg-white/25 transition"
+                      class="growth-ai-trigger inline-flex items-center gap-2 rounded-full bg-emerald-400/90 px-3.5 py-1.5 text-xs font-semibold text-night shadow-sm hover:bg-emerald-300 transition"
                       data-label="Retention"
                     >
                       <svg xmlns="http://www.w3.org/2000/svg" class="h-3.5 w-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
@@ -151,7 +147,7 @@
                       Genie tip
                     </button>
                   </div>
-                  <ul class="space-y-3 text-sm text-white/75">
+                  <ul class="space-y-3 text-base text-white/80">
                     <li>Loyalty SMS triggers 72-hour bounceback with "bring a friend" reward.</li>
                     <li>Personalized DM check-ins from Chef Bee every Friday afternoon.</li>
                   </ul>
@@ -159,12 +155,11 @@
                 <div class="relative rounded-3xl bg-gradient-to-br from-amber-400/30 via-amber-400/10 to-transparent p-6 space-y-4">
                   <div class="flex items-start justify-between gap-3">
                     <div>
-                      <p class="text-sm font-semibold text-white">Expansion</p>
-                      <p class="text-xs uppercase tracking-wide text-white/50">New lanes</p>
+                      <p class="text-lg font-semibold text-white">Expansion</p>
                     </div>
                     <button
                       type="button"
-                      class="growth-ai-trigger inline-flex items-center gap-1 rounded-full bg-white/15 px-3 py-1 text-[11px] font-medium text-white/80 hover:bg-white/25 transition"
+                      class="growth-ai-trigger inline-flex items-center gap-2 rounded-full bg-emerald-400/90 px-3.5 py-1.5 text-xs font-semibold text-night shadow-sm hover:bg-emerald-300 transition"
                       data-label="Expansion"
                     >
                       <svg xmlns="http://www.w3.org/2000/svg" class="h-3.5 w-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
@@ -173,7 +168,7 @@
                       Genie tip
                     </button>
                   </div>
-                  <ul class="space-y-3 text-sm text-white/75">
+                  <ul class="space-y-3 text-base text-white/80">
                     <li>Night Market pop-up queue with live ordering kiosk test.</li>
                     <li>Corporate catering sampler drops to tech offices on Tuesdays.</li>
                   </ul>
@@ -182,44 +177,44 @@
             </div>
 
             <div class="grid gap-6 lg:grid-cols-[1.1fr,0.9fr]">
-              <div class="rounded-3xl bg-white/10 p-7 backdrop-blur-sm space-y-6">
+              <div class="rounded-3xl bg-white/10 p-8 backdrop-blur-sm space-y-6">
                 <div class="flex items-center justify-between">
                   <h3 class="text-xl font-semibold">Plays in motion</h3>
-                  <span class="text-sm text-white/60">Live + scheduled</span>
+                  <span class="text-base text-white/70">Live + scheduled</span>
                 </div>
-                <div class="grid gap-4 sm:grid-cols-2 text-sm text-white/80">
+                <div class="grid gap-4 sm:grid-cols-2 text-base text-white/80">
                   <div class="rounded-2xl bg-emerald-400/15 p-5">
-                    <p class="text-xs uppercase tracking-wide text-white/60">This week</p>
+                    <p class="text-sm uppercase tracking-wide text-white/65">This week</p>
                     <p class="mt-3 text-lg font-semibold">Chef counter livestream</p>
                     <p class="mt-2 text-white/60">Target: 25 bookings</p>
                   </div>
                   <div class="rounded-2xl bg-cyan-400/15 p-5">
-                    <p class="text-xs uppercase tracking-wide text-white/60">Next</p>
+                    <p class="text-sm uppercase tracking-wide text-white/65">Next</p>
                     <p class="mt-3 text-lg font-semibold">UW finals comfort tour</p>
                     <p class="mt-2 text-white/60">Covers goal: 320</p>
                   </div>
                   <div class="rounded-2xl bg-violet-400/15 p-5">
-                    <p class="text-xs uppercase tracking-wide text-white/60">Testing</p>
+                    <p class="text-sm uppercase tracking-wide text-white/65">Testing</p>
                     <p class="mt-3 text-lg font-semibold">Night market pre-orders</p>
                     <p class="mt-2 text-white/60">40 orders to greenlight</p>
                   </div>
                   <div class="rounded-2xl bg-amber-400/20 p-5">
-                    <p class="text-xs uppercase tracking-wide text-white/60">Pipeline</p>
+                    <p class="text-sm uppercase tracking-wide text-white/65">Pipeline</p>
                     <p class="mt-3 text-lg font-semibold">Tech catering pilots</p>
                     <p class="mt-2 text-white/60">3 proposals pending</p>
                   </div>
                 </div>
               </div>
 
-              <aside class="rounded-3xl bg-white/10 p-7 backdrop-blur-sm space-y-5">
+              <aside class="rounded-3xl bg-white/10 p-8 backdrop-blur-sm space-y-5">
                 <div class="flex items-center justify-between">
                   <h3 class="text-xl font-semibold">AI notes</h3>
-                  <span class="inline-flex items-center gap-2 rounded-full bg-white/10 px-3 py-1 text-xs text-white/70">
+                  <span class="inline-flex items-center gap-2 rounded-full bg-white/10 px-3.5 py-1.5 text-sm text-white/75">
                     <span class="h-2 w-2 rounded-full bg-emerald-400"></span>
                     Synced
                   </span>
                 </div>
-                <ul class="space-y-3 text-sm text-white/75">
+                <ul class="space-y-3 text-base text-white/80">
                   <li class="flex items-start gap-3">
                     <span class="mt-1 h-2.5 w-2.5 rounded-full bg-emerald-400"></span>
                     Add SMS bounceback for guests who order delivery twice in a week.
@@ -239,106 +234,106 @@
 
           <div id="growth-dashboard" class="tab-panel hidden space-y-10">
             <div class="grid gap-6 md:grid-cols-4">
-              <div class="rounded-3xl bg-white/5 p-6 text-center shadow-[0_18px_30px_-25px_rgba(16,185,129,0.4)]">
-                <p class="text-sm text-white/60">Dining covers</p>
+              <div class="rounded-3xl bg-white/5 p-7 text-center shadow-[0_18px_30px_-25px_rgba(16,185,129,0.4)]">
+                <p class="text-base text-white/70">Dining covers</p>
                 <p class="mt-3 text-3xl font-semibold">186</p>
-                <p class="mt-2 text-sm text-emerald-300">+12 vs last week</p>
+                <p class="mt-2 text-base text-emerald-300">+12 vs last week</p>
               </div>
-              <div class="rounded-3xl bg-white/5 p-6 text-center shadow-[0_18px_30px_-25px_rgba(6,182,212,0.35)]">
-                <p class="text-sm text-white/60">Delivery rev</p>
+              <div class="rounded-3xl bg-white/5 p-7 text-center shadow-[0_18px_30px_-25px_rgba(6,182,212,0.35)]">
+                <p class="text-base text-white/70">Delivery rev</p>
                 <p class="mt-3 text-3xl font-semibold">$14.8k</p>
-                <p class="mt-2 text-sm text-emerald-300">+9% trailing 7d</p>
+                <p class="mt-2 text-base text-emerald-300">+9% trailing 7d</p>
               </div>
-              <div class="rounded-3xl bg-white/5 p-6 text-center shadow-[0_18px_30px_-25px_rgba(129,140,248,0.35)]">
-                <p class="text-sm text-white/60">Pipeline deals</p>
+              <div class="rounded-3xl bg-white/5 p-7 text-center shadow-[0_18px_30px_-25px_rgba(129,140,248,0.35)]">
+                <p class="text-base text-white/70">Pipeline deals</p>
                 <p class="mt-3 text-3xl font-semibold">7</p>
-                <p class="mt-2 text-sm text-emerald-300">3 near close</p>
+                <p class="mt-2 text-base text-emerald-300">3 near close</p>
               </div>
-              <div class="rounded-3xl bg-white/5 p-6 text-center shadow-[0_18px_30px_-25px_rgba(245,158,11,0.35)]">
-                <p class="text-sm text-white/60">Repeat rate</p>
+              <div class="rounded-3xl bg-white/5 p-7 text-center shadow-[0_18px_30px_-25px_rgba(245,158,11,0.35)]">
+                <p class="text-base text-white/70">Repeat rate</p>
                 <p class="mt-3 text-3xl font-semibold">28%</p>
-                <p class="mt-2 text-sm text-emerald-300">+4 pts MOM</p>
+                <p class="mt-2 text-base text-emerald-300">+4 pts MOM</p>
               </div>
             </div>
 
             <div class="grid gap-6 lg:grid-cols-[1.05fr,0.95fr]">
-              <div class="rounded-3xl bg-white/10 p-7 backdrop-blur-sm space-y-6">
+              <div class="rounded-3xl bg-white/10 p-8 backdrop-blur-sm space-y-6">
                 <div class="flex items-center justify-between">
                   <h3 class="text-xl font-semibold">Flow lane</h3>
-                  <span class="text-xs text-white/60">Goal track</span>
+                  <span class="text-sm text-white/70">Goal track</span>
                 </div>
-                <div class="space-y-5 text-sm text-white/75">
+                <div class="space-y-5 text-base text-white/80">
                   <div class="flex items-center justify-between gap-4">
                     <div>
                       <p class="font-semibold text-white/85">Awareness</p>
-                      <p class="text-xs text-white/50">Paid + organic blend</p>
+                      <p class="text-sm text-white/60">Paid + organic blend</p>
                     </div>
                     <div class="flex-1 h-2 rounded-full bg-white/10">
                       <div class="h-2 rounded-full bg-emerald-300" style="width: 76%"></div>
                     </div>
-                    <span class="text-xs text-white/60">Target 80%</span>
+                    <span class="text-sm text-white/70">Target 80%</span>
                   </div>
                   <div class="flex items-center justify-between gap-4">
                     <div>
                       <p class="font-semibold text-white/85">Booking</p>
-                      <p class="text-xs text-white/50">Reservations + walk-ins</p>
+                      <p class="text-sm text-white/60">Reservations + walk-ins</p>
                     </div>
                     <div class="flex-1 h-2 rounded-full bg-white/10">
                       <div class="h-2 rounded-full bg-emerald-300" style="width: 62%"></div>
                     </div>
-                    <span class="text-xs text-white/60">Target 75%</span>
+                    <span class="text-sm text-white/70">Target 75%</span>
                   </div>
                   <div class="flex items-center justify-between gap-4">
                     <div>
                       <p class="font-semibold text-white/85">Repeat</p>
-                      <p class="text-xs text-white/50">Loyalty + SMS</p>
+                      <p class="text-sm text-white/60">Loyalty + SMS</p>
                     </div>
                     <div class="flex-1 h-2 rounded-full bg-white/10">
                       <div class="h-2 rounded-full bg-emerald-300" style="width: 81%"></div>
                     </div>
-                    <span class="text-xs text-white/60">Target 85%</span>
+                    <span class="text-sm text-white/70">Target 85%</span>
                   </div>
                 </div>
-                <div class="rounded-2xl bg-white/10 p-5 text-sm text-white/75">
+                <div class="rounded-2xl bg-white/10 p-5 text-base text-white/80">
                   <p class="font-semibold text-white">Next actions</p>
                   <ul class="mt-3 space-y-2">
                     <li class="flex items-start gap-2">
-                      <span class="mt-1 h-2 w-2 rounded-full bg-emerald-400"></span>
+                      <span class="mt-1 h-2.5 w-2.5 rounded-full bg-emerald-400"></span>
                       Launch waitlist upsell test for 10pm rush on Thursday.
                     </li>
                     <li class="flex items-start gap-2">
-                      <span class="mt-1 h-2 w-2 rounded-full bg-cyan-400"></span>
+                      <span class="mt-1 h-2.5 w-2.5 rounded-full bg-cyan-400"></span>
                       Nudge catering prospects with chef tasting invite follow-up.
                     </li>
                     <li class="flex items-start gap-2">
-                      <span class="mt-1 h-2 w-2 rounded-full bg-violet-400"></span>
+                      <span class="mt-1 h-2.5 w-2.5 rounded-full bg-violet-400"></span>
                       Pull loyalty churn list for personal outreach cadence.
                     </li>
                   </ul>
                 </div>
               </div>
 
-              <aside class="rounded-3xl bg-white/10 p-7 backdrop-blur-sm space-y-6">
+              <aside class="rounded-3xl bg-white/10 p-8 backdrop-blur-sm space-y-6">
                 <div class="flex items-center justify-between">
                   <h3 class="text-xl font-semibold">Dashboard signals</h3>
-                  <span class="text-xs text-white/60">Ping · 5m ago</span>
+                  <span class="text-sm text-white/70">Ping · 5m ago</span>
                 </div>
-                <ul class="space-y-4 text-sm text-white/75">
+                <ul class="space-y-4 text-base text-white/80">
                   <li class="flex items-center justify-between gap-4">
                     <span>Late night wait time</span>
-                    <span class="rounded-full bg-white/10 px-3 py-1 text-xs">7 min</span>
+                    <span class="rounded-full bg-white/10 px-3 py-1 text-sm">7 min</span>
                   </li>
                   <li class="flex items-center justify-between gap-4">
                     <span>Average check size</span>
-                    <span class="rounded-full bg-white/10 px-3 py-1 text-xs">$27.40</span>
+                    <span class="rounded-full bg-white/10 px-3 py-1 text-sm">$27.40</span>
                   </li>
                   <li class="flex items-center justify-between gap-4">
                     <span>Delivery bundles sold</span>
-                    <span class="rounded-full bg-white/10 px-3 py-1 text-xs">64</span>
+                    <span class="rounded-full bg-white/10 px-3 py-1 text-sm">64</span>
                   </li>
                   <li class="flex items-center justify-between gap-4">
                     <span>Events pipeline</span>
-                    <span class="rounded-full bg-white/10 px-3 py-1 text-xs">5 warm</span>
+                    <span class="rounded-full bg-white/10 px-3 py-1 text-sm">5 warm</span>
                   </li>
                 </ul>
               </aside>

--- a/human-advisor.html
+++ b/human-advisor.html
@@ -46,17 +46,17 @@
               <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M15 19l-7-7 7-7" />
             </svg>
           </button>
-          <div class="text-4xl font-script leading-none text-white tracking-wide">genie</div>
+          <div class="text-5xl md:text-6xl font-script leading-none text-white tracking-wide">genie</div>
         </div>
         <div class="text-right">
-          <p class="text-sm text-white/70">Your AI business advisor</p>
+          <p class="text-lg md:text-xl font-medium text-white/80">Your AI business advisor</p>
         </div>
       </header>
 
       <main class="flex-1 py-10 flex flex-col gap-12">
         <section class="max-w-4xl">
           <h1 class="text-5xl md:text-6xl font-light">Human Advisor</h1>
-          <p class="mt-3 text-base text-white/70">Direct line to your dedicated operator — chat or hop on a call.</p>
+          <p class="mt-3 text-lg text-white/70">Direct line to your dedicated operator — chat or hop on a call.</p>
         </section>
 
         <section class="grid gap-8 lg:grid-cols-[0.95fr,1.05fr]">
@@ -65,43 +65,28 @@
               <div class="flex h-14 w-14 items-center justify-center rounded-full bg-white/20 text-lg font-semibold text-white">MO</div>
               <div>
                 <h2 class="text-xl font-semibold">Your advisor</h2>
-                <p class="mt-1 text-sm text-white/75">Mila Ortiz · Growth partner</p>
+                <p class="mt-1 text-base text-white/80">Mila Ortiz · Growth partner</p>
               </div>
             </div>
 
-            <div class="grid gap-4 sm:grid-cols-2 text-sm text-white/85">
+            <div class="grid gap-4 sm:grid-cols-2 text-base text-white/80">
               <div class="rounded-2xl bg-white/10 p-4">
-                <p class="text-xs text-white/60">Mobile</p>
+                <p class="text-base text-white/70">Mobile</p>
                 <p class="mt-2 text-white">(206) 555-0128</p>
               </div>
               <div class="rounded-2xl bg-white/10 p-4">
-                <p class="text-xs text-white/60">Email</p>
+                <p class="text-base text-white/70">Email</p>
                 <p class="mt-2 text-white">mila@suitandthai.ai</p>
               </div>
               <div class="rounded-2xl bg-white/10 p-4 sm:col-span-2">
-                <p class="text-xs text-white/60">Office hours</p>
+                <p class="text-base text-white/70">Office hours</p>
                 <p class="mt-2 text-white">Mon–Fri · 9a – 5p PT</p>
               </div>
             </div>
 
-            <div class="space-y-4 text-sm text-white/80">
-              <div class="flex items-center justify-between">
-                <h3 class="text-sm font-semibold text-white">Upcoming</h3>
-                <span class="rounded-full bg-white/15 px-3 py-1 text-xs text-white/70">Synced</span>
-              </div>
-              <div class="rounded-2xl bg-white/10 p-4">
-                <p class="text-white">Night Market budget review</p>
-                <p class="text-xs text-white/60 mt-1">Today · 3:30p PT · 30 min</p>
-              </div>
-              <div class="rounded-2xl bg-white/10 p-4">
-                <p class="text-white">Influencer dinner recap</p>
-                <p class="text-xs text-white/60 mt-1">Thu · 11:00a PT · 20 min</p>
-              </div>
-            </div>
-
             <div class="space-y-3">
-              <h3 class="text-sm font-semibold text-white">Quick actions</h3>
-              <div class="grid grid-cols-2 gap-3 text-sm">
+              <h3 class="text-base font-semibold text-white">Quick actions</h3>
+              <div class="grid grid-cols-2 gap-3 text-base">
                 <button class="inline-flex items-center justify-center gap-2 rounded-2xl bg-white text-black px-4 py-2 font-semibold hover:bg-white/90 transition">
                   <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
                     <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M7 8h10M7 12h6m-6 4h6m8-4a9 9 0 11-18 0 9 9 0 0118 0z" />
@@ -124,33 +109,33 @@
             </div>
           </aside>
 
-          <div class="rounded-3xl bg-white/10 p-6 lg:p-7 flex flex-col backdrop-blur-sm shadow-[0_20px_45px_-30px_rgba(14,165,233,0.45)] ring-1 ring-white/10">
+          <div class="rounded-3xl bg-white/10 p-7 lg:p-8 flex flex-col backdrop-blur-sm shadow-[0_20px_45px_-30px_rgba(14,165,233,0.45)] ring-1 ring-white/10">
             <div class="flex flex-wrap items-center justify-between gap-3 border-b border-white/10 pb-4">
               <div>
                 <h2 class="text-xl font-semibold">Session board</h2>
-                <p class="text-sm text-white/60">Catch up or drop a note before the call.</p>
+                <p class="text-base text-white/70">Catch up or drop a note before the call.</p>
               </div>
-              <div class="inline-flex items-center gap-2 rounded-full bg-white/10 px-3 py-1 text-xs text-white/75">
+              <div class="inline-flex items-center gap-2 rounded-full bg-white/10 px-3.5 py-1.5 text-sm text-white/75">
                 <span class="h-2 w-2 rounded-full bg-emerald-400"></span>
                 Mila is online
               </div>
             </div>
 
-            <div class="flex-1 overflow-y-auto py-6 space-y-5 text-sm text-white/80">
+            <div class="flex-1 overflow-y-auto py-6 space-y-5 text-base text-white/80">
               <div class="space-y-2">
-                <p class="text-xs text-white/50">Yesterday · 4:12p</p>
+                <p class="text-base text-white/70">Yesterday · 4:12p</p>
                 <div class="max-w-xl rounded-2xl bg-white/10 px-4 py-3">
                   Looking over Night Market staffing. Anything you want me to prep before tomorrow?
                 </div>
               </div>
               <div class="space-y-2 text-right">
-                <p class="text-xs text-white/50">You · 4:18p</p>
+                <p class="text-base text-white/70">You · 4:18p</p>
                 <div class="ml-auto max-w-xl rounded-2xl bg-gradient-to-r from-rose-500/50 via-rose-500/20 to-white/10 px-4 py-3 text-left">
                   Could you stress test the 10pm rush forecast and flag if we need a third POS?
                 </div>
               </div>
               <div class="space-y-2">
-                <p class="text-xs text-white/50">Today · 9:07a</p>
+                <p class="text-base text-white/70">Today · 9:07a</p>
                 <div class="max-w-xl rounded-2xl bg-white/10 px-4 py-3">
                   Running numbers now — expect a note in the doc by noon. Want to add a 15-min sync?
                 </div>
@@ -160,10 +145,10 @@
             <form class="border-t border-white/10 pt-4 space-y-3" onsubmit="event.preventDefault();">
               <textarea
                 rows="3"
-                class="w-full rounded-2xl border border-white/20 bg-transparent p-4 text-sm text-white placeholder:text-white/40 focus:border-white focus:outline-none"
+                class="w-full rounded-2xl border border-white/20 bg-transparent p-4 text-base text-white placeholder:text-white/40 focus:border-white focus:outline-none"
                 placeholder="Update Mila before the next call…"
               ></textarea>
-              <div class="flex flex-wrap items-center justify-between gap-3 text-sm">
+              <div class="flex flex-wrap items-center justify-between gap-3 text-base">
                 <div class="flex items-center gap-2 text-white/60">
                   <button type="button" class="inline-flex items-center gap-2 rounded-full border border-white/25 px-3 py-1 hover:border-white/60 transition">
                     <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">

--- a/inventory.html
+++ b/inventory.html
@@ -9,7 +9,7 @@
         theme: {
           extend: {
             fontFamily: {
-              script: ['"Dancing Script"', 'cursive'],
+              script: ['"Pacifico"', '"Allura"', 'cursive'],
               sans: ['"Manrope"', 'system-ui', 'sans-serif'],
             },
             colors: {
@@ -24,7 +24,7 @@
     <script src="https://cdn.tailwindcss.com"></script>
     <link
       rel="stylesheet"
-      href="https://fonts.googleapis.com/css2?family=Dancing+Script:wght@500;600&family=Manrope:wght@400;500;600;700&display=swap"
+      href="https://fonts.googleapis.com/css2?family=Allura&family=Manrope:wght@400;500;600;700&family=Pacifico&display=swap"
     />
     <style>
       body {
@@ -46,10 +46,10 @@
               <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M15 19l-7-7 7-7" />
             </svg>
           </button>
-          <div class="text-4xl font-script leading-none text-white">genie</div>
+          <div class="text-5xl md:text-6xl font-script leading-none text-white">genie</div>
         </div>
         <div class="text-right">
-          <p class="text-sm text-white/70">Your AI business advisor</p>
+          <p class="text-lg md:text-xl font-medium text-white/80">Your AI business advisor</p>
         </div>
       </header>
 

--- a/marketing.html
+++ b/marketing.html
@@ -46,30 +46,30 @@
               <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M15 19l-7-7 7-7" />
             </svg>
           </button>
-          <div class="text-4xl font-script leading-none text-white tracking-wide">genie</div>
+          <div class="text-5xl md:text-6xl font-script leading-none text-white tracking-wide">genie</div>
         </div>
         <div class="text-right">
-          <p class="text-sm text-white/70">Your AI business advisor</p>
+          <p class="text-lg md:text-xl font-medium text-white/80">Your AI business advisor</p>
         </div>
       </header>
 
       <main class="flex-1 py-10 flex flex-col gap-12">
         <section class="max-w-4xl">
           <h1 class="text-5xl md:text-6xl font-light">Marketing</h1>
-          <p class="mt-3 text-base text-white/70">Optimisze your outreach.</p>
+          <p class="mt-3 text-lg text-white/70">Optimisze your outreach.</p>
         </section>
 
         <section class="space-y-12">
           <div class="flex flex-wrap items-center justify-between gap-4">
-            <div class="inline-flex rounded-full bg-white/5 p-1 text-sm">
-              <button class="tab-trigger rounded-full px-4 py-2 font-medium bg-white text-black" data-target="marketing-strategy">
+            <div class="inline-flex rounded-full bg-white/5 p-1 text-base">
+              <button class="tab-trigger rounded-full px-5 py-2 font-semibold bg-white text-black" data-target="marketing-strategy">
                 Strategy
               </button>
-              <button class="tab-trigger rounded-full px-4 py-2 font-medium text-white/70 hover:text-white transition" data-target="marketing-dashboard">
+              <button class="tab-trigger rounded-full px-5 py-2 font-semibold text-white/75 hover:text-white transition" data-target="marketing-dashboard">
                 Dashboard
               </button>
             </div>
-            <span class="text-sm text-white/60">Last refreshed · 3 minutes ago</span>
+            <span class="text-base text-white/70">Last refreshed · 3 minutes ago</span>
           </div>
 
           <div id="marketing-strategy" class="tab-panel space-y-12">
@@ -77,18 +77,15 @@
               <div class="flex flex-wrap items-start justify-between gap-6">
                 <div>
                   <h2 class="text-2xl font-semibold">Strategy</h2>
-          <p class="mt-2 text-white/65 max-w-xl">
-                    Four focused lanes to keep Suit and Thai top of mind with the right guests every day.
-                  </p>
                 </div>
                 <button
                   type="button"
-                  class="ai-trigger inline-flex items-center gap-2 rounded-full bg-rose-500 px-4 py-2 text-sm font-semibold shadow-lg hover:bg-rose-400 transition"
+                  class="ai-trigger inline-flex items-center gap-2 rounded-full bg-emerald-400 px-5 py-2.5 text-base font-semibold text-night shadow-lg hover:bg-emerald-300 transition"
                   data-marketing-ai="overview"
                   data-label="Strategy overview"
                 >
                   <span class="inline-block h-2 w-2 rounded-full bg-white animate-pulse"></span>
-                  AI suggestion
+                  Genie tip
                 </button>
               </div>
 
@@ -96,12 +93,11 @@
                 <div class="relative rounded-3xl bg-gradient-to-br from-fuchsia-500/25 via-fuchsia-500/10 to-transparent p-6 space-y-4">
                   <div class="flex items-start justify-between gap-3">
                     <div>
-                      <p class="text-sm font-semibold text-white">Social media</p>
-                      <p class="text-xs uppercase tracking-wide text-white/50">Next 7 days</p>
+                      <p class="text-lg font-semibold text-white">Social Media</p>
                     </div>
                     <button
                       type="button"
-                      class="ai-trigger inline-flex items-center gap-1 rounded-full bg-white/15 px-3 py-1 text-[11px] font-medium text-white/80 hover:bg-white/25 transition"
+                      class="ai-trigger inline-flex items-center gap-2 rounded-full bg-emerald-400/90 px-3.5 py-1.5 text-xs font-semibold text-night shadow-sm hover:bg-emerald-300 transition"
                       data-marketing-ai="social"
                       data-label="Social media"
                     >
@@ -111,7 +107,7 @@
                       Genie tip
                     </button>
                   </div>
-                  <ul class="space-y-3 text-sm text-white/75">
+                  <ul class="space-y-3 text-base text-white/80">
                     <li>Night Market teaser reel + duet reply to top comment.</li>
                     <li>Campus study break poll layered with finals countdown sticker.</li>
                   </ul>
@@ -119,12 +115,11 @@
                 <div class="relative rounded-3xl bg-gradient-to-br from-sky-400/25 via-sky-400/10 to-transparent p-6 space-y-4">
                   <div class="flex items-start justify-between gap-3">
                     <div>
-                      <p class="text-sm font-semibold text-white">Community</p>
-                      <p class="text-xs uppercase tracking-wide text-white/50">Superfans</p>
+                      <p class="text-lg font-semibold text-white">Community</p>
                     </div>
                     <button
                       type="button"
-                      class="ai-trigger inline-flex items-center gap-1 rounded-full bg-white/15 px-3 py-1 text-[11px] font-medium text-white/80 hover:bg-white/25 transition"
+                      class="ai-trigger inline-flex items-center gap-2 rounded-full bg-emerald-400/90 px-3.5 py-1.5 text-xs font-semibold text-night shadow-sm hover:bg-emerald-300 transition"
                       data-marketing-ai="community"
                       data-label="Community"
                     >
@@ -134,7 +129,7 @@
                       Genie tip
                     </button>
                   </div>
-                  <ul class="space-y-3 text-sm text-white/75">
+                  <ul class="space-y-3 text-base text-white/80">
                     <li>Superfan text loop with "unlock a chef story" responses.</li>
                     <li>Discord drop: finals survival kit with live Q&A slot poll.</li>
                   </ul>
@@ -142,12 +137,11 @@
                 <div class="relative rounded-3xl bg-gradient-to-br from-emerald-400/25 via-emerald-400/10 to-transparent p-6 space-y-4">
                   <div class="flex items-start justify-between gap-3">
                     <div>
-                      <p class="text-sm font-semibold text-white">Loyalty</p>
-                      <p class="text-xs uppercase tracking-wide text-white/50">Guests on file</p>
+                      <p class="text-lg font-semibold text-white">Loyalty</p>
                     </div>
                     <button
                       type="button"
-                      class="ai-trigger inline-flex items-center gap-1 rounded-full bg-white/15 px-3 py-1 text-[11px] font-medium text-white/80 hover:bg-white/25 transition"
+                      class="ai-trigger inline-flex items-center gap-2 rounded-full bg-emerald-400/90 px-3.5 py-1.5 text-xs font-semibold text-night shadow-sm hover:bg-emerald-300 transition"
                       data-marketing-ai="loyalty"
                       data-label="Loyalty"
                     >
@@ -157,7 +151,7 @@
                       Genie tip
                     </button>
                   </div>
-                  <ul class="space-y-3 text-sm text-white/75">
+                  <ul class="space-y-3 text-base text-white/80">
                     <li>72-hour bounceback SMS with auto-loaded dessert add-on.</li>
                     <li>Segmented email spotlighting "study buddy" table bundles.</li>
                   </ul>
@@ -165,12 +159,11 @@
                 <div class="relative rounded-3xl bg-gradient-to-br from-amber-400/30 via-amber-400/10 to-transparent p-6 space-y-4">
                   <div class="flex items-start justify-between gap-3">
                     <div>
-                      <p class="text-sm font-semibold text-white">Partnerships</p>
-                      <p class="text-xs uppercase tracking-wide text-white/50">Local reach</p>
+                      <p class="text-lg font-semibold text-white">Partnerships</p>
                     </div>
                     <button
                       type="button"
-                      class="ai-trigger inline-flex items-center gap-1 rounded-full bg-white/15 px-3 py-1 text-[11px] font-medium text-white/80 hover:bg-white/25 transition"
+                      class="ai-trigger inline-flex items-center gap-2 rounded-full bg-emerald-400/90 px-3.5 py-1.5 text-xs font-semibold text-night shadow-sm hover:bg-emerald-300 transition"
                       data-marketing-ai="partnerships"
                       data-label="Partnerships"
                     >
@@ -180,7 +173,7 @@
                       Genie tip
                     </button>
                   </div>
-                  <ul class="space-y-3 text-sm text-white/75">
+                  <ul class="space-y-3 text-base text-white/80">
                     <li>Co-host late-night cram bar with Hugo House writing center.</li>
                     <li>Table topper swaps with Night Market vendors for cross-plug.</li>
                   </ul>
@@ -190,15 +183,15 @@
 
             <div class="grid gap-6 lg:grid-cols-[1.15fr,0.85fr]">
               <div class="space-y-6">
-                <div class="rounded-3xl bg-white/10 p-6 backdrop-blur-sm">
+                <div class="rounded-3xl bg-white/10 p-7 backdrop-blur-sm">
                   <div class="flex items-center justify-between">
                     <h3 class="text-xl font-semibold">AI insights / thoughts</h3>
-                    <span class="inline-flex items-center gap-2 rounded-full bg-white/10 px-3 py-1 text-xs text-white/70">
+                    <span class="inline-flex items-center gap-2 rounded-full bg-white/10 px-3.5 py-1.5 text-sm text-white/75">
                       <span class="h-2 w-2 rounded-full bg-emerald-400"></span>
                       Synced 2m ago
                     </span>
                   </div>
-                  <ul class="mt-5 space-y-3 text-sm text-white/75">
+                  <ul class="mt-5 space-y-3 text-base text-white/80">
                     <li class="flex gap-3">
                       <span class="mt-1 h-2.5 w-2.5 rounded-full bg-rose-400"></span>
                       TikTok replies mentioning "study" correlate with +18% late-night orders — double down on finals framing this week.
@@ -214,29 +207,29 @@
                   </ul>
                 </div>
 
-                <div class="rounded-3xl bg-white/10 p-6 backdrop-blur-sm">
+                <div class="rounded-3xl bg-white/10 p-7 backdrop-blur-sm">
                   <div class="flex items-center justify-between">
                     <h3 class="text-xl font-semibold">Channel board</h3>
-                    <span class="text-xs text-white/60">Week of May 13</span>
+                    <span class="text-sm text-white/70">Week of May 13</span>
                   </div>
-                  <div class="mt-5 grid gap-4 sm:grid-cols-2 text-sm text-white/80">
+                  <div class="mt-5 grid gap-4 sm:grid-cols-2 text-base text-white/80">
                     <div class="rounded-2xl bg-white/10 p-5 space-y-2">
-                      <p class="text-xs uppercase tracking-wide text-white/50">Social</p>
+                      <p class="text-sm uppercase tracking-wide text-white/60">Social</p>
                       <p class="text-lg font-semibold">Midnight Market hype</p>
                       <p class="text-white/60">Reel + duet chain, publish Wed 7p.</p>
                     </div>
                     <div class="rounded-2xl bg-white/10 p-5 space-y-2">
-                      <p class="text-xs uppercase tracking-wide text-white/50">Email</p>
+                      <p class="text-sm uppercase tracking-wide text-white/60">Email</p>
                       <p class="text-lg font-semibold">Study buddy bundles</p>
                       <p class="text-white/60">Segment: loyalty tiers A/B.</p>
                     </div>
                     <div class="rounded-2xl bg-white/10 p-5 space-y-2">
-                      <p class="text-xs uppercase tracking-wide text-white/50">PR</p>
+                      <p class="text-sm uppercase tracking-wide text-white/60">PR</p>
                       <p class="text-lg font-semibold">Night Market preview</p>
                       <p class="text-white/60">Media list locked · send Tue 9a.</p>
                     </div>
                     <div class="rounded-2xl bg-white/10 p-5 space-y-2">
-                      <p class="text-xs uppercase tracking-wide text-white/50">Community</p>
+                      <p class="text-sm uppercase tracking-wide text-white/60">Community</p>
                       <p class="text-lg font-semibold">Superfan check-in</p>
                       <p class="text-white/60">Voice memo drop Friday noon.</p>
                     </div>
@@ -244,32 +237,32 @@
                 </div>
               </div>
 
-              <aside class="rounded-3xl bg-white/10 p-6 space-y-5 backdrop-blur-sm">
+              <aside class="rounded-3xl bg-white/10 p-7 space-y-5 backdrop-blur-sm">
                 <div class="flex items-center justify-between">
                   <h3 class="text-xl font-semibold">Collab tracker</h3>
-                  <span class="text-xs text-white/60">3 active threads</span>
+                  <span class="text-sm text-white/70">3 active threads</span>
                 </div>
-                <ul class="space-y-4 text-sm text-white/75">
+                <ul class="space-y-4 text-base text-white/80">
                   <li class="rounded-2xl bg-white/10 p-4">
                     <div class="flex items-center justify-between">
                       <p class="font-semibold text-white/85">UW Esports Lounge</p>
-                      <span class="rounded-full bg-emerald-400/20 px-3 py-1 text-xs text-emerald-200">Go</span>
+                      <span class="rounded-full bg-emerald-400/20 px-3 py-1 text-sm text-emerald-200">Go</span>
                     </div>
-                    <p class="mt-2 text-white/60">Joint finals watch party · promo assets approved.</p>
+                    <p class="mt-2 text-white/65">Finals watch party locked; promo kit queued.</p>
                   </li>
                   <li class="rounded-2xl bg-white/10 p-4">
                     <div class="flex items-center justify-between">
                       <p class="font-semibold text-white/85">Seattle Night Market</p>
-                      <span class="rounded-full bg-amber-400/20 px-3 py-1 text-xs text-amber-200">Prep</span>
+                      <span class="rounded-full bg-amber-400/20 px-3 py-1 text-sm text-amber-200">Prep</span>
                     </div>
-                    <p class="mt-2 text-white/60">Menu finalized, signage proof due Wednesday.</p>
+                    <p class="mt-2 text-white/65">Menu signed off; signage proof arrives Wednesday.</p>
                   </li>
                   <li class="rounded-2xl bg-white/10 p-4">
                     <div class="flex items-center justify-between">
                       <p class="font-semibold text-white/85">Chef Bee podcast</p>
-                      <span class="rounded-full bg-rose-400/20 px-3 py-1 text-xs text-rose-200">Pitch</span>
+                      <span class="rounded-full bg-rose-400/20 px-3 py-1 text-sm text-rose-200">Pitch</span>
                     </div>
-                    <p class="mt-2 text-white/60">Episode outline in draft — waiting on producer feedback.</p>
+                    <p class="mt-2 text-white/65">Outline drafted; awaiting producer notes.</p>
                   </li>
                 </ul>
               </aside>
@@ -278,75 +271,75 @@
 
           <div id="marketing-dashboard" class="tab-panel hidden space-y-10">
             <div class="grid gap-6 md:grid-cols-4">
-              <div class="rounded-3xl bg-white/5 p-6 text-center shadow-[0_18px_30px_-25px_rgba(244,114,182,0.45)]">
-                <p class="text-sm text-white/60">Reach lift</p>
+              <div class="rounded-3xl bg-white/5 p-7 text-center shadow-[0_18px_30px_-25px_rgba(244,114,182,0.45)]">
+                <p class="text-base text-white/70">Reach lift</p>
                 <p class="mt-3 text-3xl font-semibold">+18%</p>
-                <p class="mt-2 text-sm text-emerald-300">vs last 7 days</p>
+                <p class="mt-2 text-base text-emerald-300">vs last 7 days</p>
               </div>
-              <div class="rounded-3xl bg-white/5 p-6 text-center shadow-[0_18px_30px_-25px_rgba(56,189,248,0.4)]">
-                <p class="text-sm text-white/60">New subscribers</p>
+              <div class="rounded-3xl bg-white/5 p-7 text-center shadow-[0_18px_30px_-25px_rgba(56,189,248,0.4)]">
+                <p class="text-base text-white/70">New subscribers</p>
                 <p class="mt-3 text-3xl font-semibold">312</p>
-                <p class="mt-2 text-sm text-emerald-300">SMS + email</p>
+                <p class="mt-2 text-base text-emerald-300">SMS + email</p>
               </div>
-              <div class="rounded-3xl bg-white/5 p-6 text-center shadow-[0_18px_30px_-25px_rgba(16,185,129,0.35)]">
-                <p class="text-sm text-white/60">Press momentum</p>
+              <div class="rounded-3xl bg-white/5 p-7 text-center shadow-[0_18px_30px_-25px_rgba(16,185,129,0.35)]">
+                <p class="text-base text-white/70">Press momentum</p>
                 <p class="mt-3 text-3xl font-semibold">6</p>
-                <p class="mt-2 text-sm text-emerald-300">Features in flight</p>
+                <p class="mt-2 text-base text-emerald-300">Features in flight</p>
               </div>
-              <div class="rounded-3xl bg-white/5 p-6 text-center shadow-[0_18px_30px_-25px_rgba(251,191,36,0.35)]">
-                <p class="text-sm text-white/60">Promo ROI</p>
+              <div class="rounded-3xl bg-white/5 p-7 text-center shadow-[0_18px_30px_-25px_rgba(251,191,36,0.35)]">
+                <p class="text-base text-white/70">Promo ROI</p>
                 <p class="mt-3 text-3xl font-semibold">3.4×</p>
-                <p class="mt-2 text-sm text-emerald-300">Trailing 14d</p>
+                <p class="mt-2 text-base text-emerald-300">Trailing 14d</p>
               </div>
             </div>
 
             <div class="grid gap-6 lg:grid-cols-[1.1fr,0.9fr]">
-              <div class="rounded-3xl bg-white/5 p-7 space-y-6">
+              <div class="rounded-3xl bg-white/5 p-8 space-y-6">
                 <div class="flex items-center justify-between">
                   <h3 class="text-xl font-semibold">Dashboard view</h3>
-                  <span class="text-xs text-white/60">Auto-updated hourly</span>
+                  <span class="text-sm text-white/70">Auto-updated hourly</span>
                 </div>
-                <div class="space-y-4 text-sm text-white/75">
+                <div class="space-y-4 text-base text-white/80">
                   <div class="flex items-center justify-between gap-4">
                     <div>
                       <p class="font-semibold text-white/85">Organic</p>
-                      <p class="text-xs text-white/50">Reach + saves</p>
+                      <p class="text-sm text-white/60">Reach + saves</p>
                     </div>
                     <div class="flex-1 h-2 rounded-full bg-white/10">
                       <div class="h-2 rounded-full bg-fuchsia-400" style="width: 74%"></div>
                     </div>
-                    <span class="text-xs text-white/60">Goal 80%</span>
+                    <span class="text-sm text-white/70">Goal 80%</span>
                   </div>
                   <div class="flex items-center justify-between gap-4">
                     <div>
                       <p class="font-semibold text-white/85">Paid</p>
-                      <p class="text-xs text-white/50">Spend vs plan</p>
+                      <p class="text-sm text-white/60">Spend vs plan</p>
                     </div>
                     <div class="flex-1 h-2 rounded-full bg-white/10">
                       <div class="h-2 rounded-full bg-sky-400" style="width: 61%"></div>
                     </div>
-                    <span class="text-xs text-white/60">Goal 70%</span>
+                    <span class="text-sm text-white/70">Goal 70%</span>
                   </div>
                   <div class="flex items-center justify-between gap-4">
                     <div>
                       <p class="font-semibold text-white/85">Community</p>
-                      <p class="text-xs text-white/50">DMs + replies</p>
+                      <p class="text-sm text-white/60">DMs + replies</p>
                     </div>
                     <div class="flex-1 h-2 rounded-full bg-white/10">
                       <div class="h-2 rounded-full bg-emerald-400" style="width: 88%"></div>
                     </div>
-                    <span class="text-xs text-white/60">Goal 90%</span>
+                    <span class="text-sm text-white/70">Goal 90%</span>
                   </div>
                 </div>
-                <div class="rounded-2xl bg-white/10 p-5 text-sm text-white/75">
+                <div class="rounded-2xl bg-white/10 p-5 text-base text-white/80">
                   <p class="font-semibold text-white">Upcoming checks</p>
                   <ul class="mt-3 space-y-2">
                     <li class="flex items-start gap-2">
-                      <span class="mt-1 h-2 w-2 rounded-full bg-sky-400"></span>
+                      <span class="mt-1 h-2.5 w-2.5 rounded-full bg-sky-400"></span>
                       Refresh influencer list with finals-specific voices.
                     </li>
                     <li class="flex items-start gap-2">
-                      <span class="mt-1 h-2 w-2 rounded-full bg-rose-400"></span>
+                      <span class="mt-1 h-2.5 w-2.5 rounded-full bg-rose-400"></span>
                       Review CTA variants for Midnight Market landing page.
                     </li>
                     <li class="flex items-start gap-2">
@@ -362,7 +355,7 @@
                   <h3 class="text-xl font-semibold">Signals</h3>
                   <span class="text-xs text-white/60">Latest ping · 9:12p</span>
                 </div>
-                <ul class="space-y-4 text-sm text-white/75">
+                <ul class="space-y-4 text-base text-white/80">
                   <li class="flex items-center justify-between gap-4">
                     <span>PR mentions</span>
                     <span class="rounded-full bg-white/10 px-3 py-1 text-xs">3 live</span>


### PR DESCRIPTION
## Summary
- Enlarge the demo header, icons, and app tiles while switching Genie branding across pages to the Pacifico/Allura script
- Refresh marketing, growth, competitors, and human advisor views with brighter Genie tip buttons, larger typography, and updated content per feedback
- Simplify the experiment wall layout with a lighter container, forked arrow visualization, and richer modal/card styling

## Testing
- No automated tests were run (static HTML/CSS updates)


------
https://chatgpt.com/codex/tasks/task_e_68d188bcc0a0832fa7d8b2a5491a25d5