### PR TITLE
Adjust Genie styling and interactions

### DIFF
--- a/ai-companion.html
+++ b/ai-companion.html
@@ -29,6 +29,10 @@
         background: radial-gradient(circle at top left, rgba(125, 211, 252, 0.18), transparent 45%),
           radial-gradient(circle at top right, rgba(129, 140, 248, 0.16), transparent 50%), #050508;
       }
+
+      .font-script {
+        font-family: 'Pacifico', 'Allura', cursive !important;
+      }
     </style>
   </head>
   <body class="min-h-screen bg-night text-white font-sans">
@@ -44,10 +48,7 @@
               <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M15 19l-7-7 7-7" />
             </svg>
           </button>
-          <div>
-            <div class="text-5xl md:text-6xl font-script leading-none text-white tracking-wide">genie</div>
-            <p class="text-sm text-white/65">Copilot chat</p>
-          </div>
+          <div class="text-5xl md:text-6xl font-script leading-none text-white tracking-wide">genie</div>
         </div>
         <div class="text-right text-sm text-white/60">Suit and Thai · Always on</div>
       </header>

--- a/competitors.html
+++ b/competitors.html
@@ -31,6 +31,10 @@
         background: radial-gradient(circle at top left, rgba(59, 130, 246, 0.18), transparent 45%),
           radial-gradient(circle at top right, rgba(147, 51, 234, 0.16), transparent 50%), #050508;
       }
+
+      .font-script {
+        font-family: 'Pacifico', 'Allura', cursive !important;
+      }
     </style>
   </head>
   <body class="min-h-screen bg-night text-white font-sans">
@@ -77,8 +81,8 @@
                   <span class="rounded-full bg-white/10 px-3 py-1 text-sm">$19</span>
                 </li>
                 <li class="flex items-center justify-between">
-                  <span>Signature play</span>
-                  <span class="rounded-full bg-white/10 px-3 py-1 text-sm">Late-night wok show</span>
+                  <span>Menu spotlight</span>
+                  <span class="rounded-full bg-white/10 px-3 py-1 text-sm">Wok fire tasting</span>
                 </li>
               </ul>
             </article>
@@ -98,8 +102,8 @@
                   <span class="rounded-full bg-white/10 px-3 py-1 text-sm">$24</span>
                 </li>
                 <li class="flex items-center justify-between">
-                  <span>Signature play</span>
-                  <span class="rounded-full bg-white/10 px-3 py-1 text-sm">Chef tasting nights</span>
+                  <span>Menu spotlight</span>
+                  <span class="rounded-full bg-white/10 px-3 py-1 text-sm">Chef tasting flight</span>
                 </li>
               </ul>
             </article>
@@ -119,8 +123,8 @@
                   <span class="rounded-full bg-white/10 px-3 py-1 text-sm">$32</span>
                 </li>
                 <li class="flex items-center justify-between">
-                  <span>Signature play</span>
-                  <span class="rounded-full bg-white/10 px-3 py-1 text-sm">Garden patio parties</span>
+                  <span>Menu spotlight</span>
+                  <span class="rounded-full bg-white/10 px-3 py-1 text-sm">Lantern supper club</span>
                 </li>
               </ul>
             </article>
@@ -140,8 +144,8 @@
                   <span class="rounded-full bg-white/10 px-3 py-1 text-sm">$27</span>
                 </li>
                 <li class="flex items-center justify-between">
-                  <span>Signature play</span>
-                  <span class="rounded-full bg-white/10 px-3 py-1 text-sm">Family heat kits</span>
+                  <span>Menu spotlight</span>
+                  <span class="rounded-full bg-white/10 px-3 py-1 text-sm">Heat-kit bundles</span>
                 </li>
               </ul>
             </article>
@@ -152,7 +156,7 @@
               <button class="tab-trigger rounded-full px-5 py-2 font-semibold bg-white text-black" data-target="competitors-strategy">
                 Strategy
               </button>
-              <button class="tab-trigger rounded-full px-5 py-2 font-semibold text-white/75 hover:text-white transition" data-target="competitors-dashboard">
+              <button class="tab-trigger rounded-full px-5 py-2 font-semibold text-white/70 hover:text-white transition" data-target="competitors-dashboard">
                 Dashboard
               </button>
             </div>
@@ -167,7 +171,7 @@
               </div>
               <button
                 type="button"
-                class="competitor-ai-trigger inline-flex items-center gap-2 rounded-full bg-emerald-400 px-5 py-2.5 text-base font-semibold text-night shadow-lg hover:bg-emerald-300 transition"
+                class="competitor-ai-trigger inline-flex items-center gap-2 rounded-full bg-emerald-500 px-5 py-2.5 text-base font-semibold text-night shadow-lg hover:bg-emerald-400 transition"
                 data-label="Landscape overview"
               >
                 <span class="inline-block h-2 w-2 rounded-full bg-white animate-pulse"></span>
@@ -177,96 +181,98 @@
 
             <div class="grid gap-6 lg:grid-cols-[1.1fr,0.9fr]">
               <div class="space-y-6">
-                <div class="rounded-3xl bg-white/10 p-7 backdrop-blur-sm space-y-5">
-                  <h3 class="text-xl font-semibold">Competitor watchlist</h3>
-                  <div class="grid gap-4 sm:grid-cols-2 text-base text-white/80">
-                    <div class="rounded-2xl bg-white/10 p-4 space-y-2">
-                      <div class="flex items-center justify-between">
-                        <p class="font-semibold text-white">Thai Tom</p>
-                        <span class="rounded-full bg-emerald-400/20 px-3 py-1 text-sm text-emerald-200">Hot</span>
+                <div class="grid gap-6 xl:grid-cols-[1.1fr,0.9fr]">
+                  <div class="rounded-3xl bg-white/10 p-7 backdrop-blur-sm space-y-5">
+                    <h3 class="text-xl font-semibold">Competitor watchlist</h3>
+                    <div class="grid gap-4 sm:grid-cols-2 text-base text-white/80">
+                      <div class="rounded-2xl bg-white/10 p-4 space-y-2">
+                        <div class="flex items-center justify-between">
+                          <p class="font-semibold text-white">Thai Tom</p>
+                          <span class="rounded-full bg-emerald-400/20 px-3 py-1 text-sm text-emerald-200">Hot</span>
+                        </div>
+                        <p class="text-white/65">Night wok show content spiking 32% shares.</p>
+                        <button
+                          type="button"
+                          class="competitor-ai-trigger inline-flex items-center gap-2 rounded-full bg-emerald-500/90 px-3.5 py-1.5 text-xs font-semibold text-night shadow-sm hover:bg-emerald-400 transition"
+                          data-label="Thai Tom"
+                        >
+                          <svg xmlns="http://www.w3.org/2000/svg" class="h-3.5 w-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M12 3v3m0 12v3m9-9h-3M6 12H3m15.364 6.364-2.121-2.121M8.757 8.757 6.636 6.636m12.728 0-2.121 2.121M8.757 15.243l-2.121 2.121" />
+                          </svg>
+                          Genie tip
+                        </button>
                       </div>
-                      <p class="text-white/65">Night wok show content spiking 32% shares.</p>
-                      <button
-                        type="button"
-                        class="competitor-ai-trigger inline-flex items-center gap-2 rounded-full bg-emerald-400/90 px-3.5 py-1.5 text-xs font-semibold text-night shadow-sm hover:bg-emerald-300 transition"
-                        data-label="Thai Tom"
-                      >
-                        <svg xmlns="http://www.w3.org/2000/svg" class="h-3.5 w-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M12 3v3m0 12v3m9-9h-3M6 12H3m15.364 6.364-2.121-2.121M8.757 8.757 6.636 6.636m12.728 0-2.121 2.121M8.757 15.243l-2.121 2.121" />
-                        </svg>
-                        Genie tip
-                      </button>
-                    </div>
-                    <div class="rounded-2xl bg-white/10 p-4 space-y-2">
-                      <div class="flex items-center justify-between">
-                        <p class="font-semibold text-white">Pinto Bistro</p>
-                        <span class="rounded-full bg-sky-400/20 px-3 py-1 text-sm text-sky-200">Watch</span>
+                      <div class="rounded-2xl bg-white/10 p-4 space-y-2">
+                        <div class="flex items-center justify-between">
+                          <p class="font-semibold text-white">Pinto Bistro</p>
+                          <span class="rounded-full bg-sky-400/20 px-3 py-1 text-sm text-sky-200">Watch</span>
+                        </div>
+                        <p class="text-white/65">Weekend brunch PR adds 11 earned hits in 14 days.</p>
+                        <button
+                          type="button"
+                          class="competitor-ai-trigger inline-flex items-center gap-2 rounded-full bg-emerald-500/90 px-3.5 py-1.5 text-xs font-semibold text-night shadow-sm hover:bg-emerald-400 transition"
+                          data-label="Pinto Bistro"
+                        >
+                          <svg xmlns="http://www.w3.org/2000/svg" class="h-3.5 w-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M12 3v3m0 12v3m9-9h-3M6 12H3m15.364 6.364-2.121-2.121M8.757 8.757 6.636 6.636m12.728 0-2.121 2.121M8.757 15.243l-2.121 2.121" />
+                          </svg>
+                          Genie tip
+                        </button>
                       </div>
-                      <p class="text-white/65">Weekend brunch PR adds 11 earned hits in 14 days.</p>
-                      <button
-                        type="button"
-                        class="competitor-ai-trigger inline-flex items-center gap-2 rounded-full bg-emerald-400/90 px-3.5 py-1.5 text-xs font-semibold text-night shadow-sm hover:bg-emerald-300 transition"
-                        data-label="Pinto Bistro"
-                      >
-                        <svg xmlns="http://www.w3.org/2000/svg" class="h-3.5 w-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M12 3v3m0 12v3m9-9h-3M6 12H3m15.364 6.364-2.121-2.121M8.757 8.757 6.636 6.636m12.728 0-2.121 2.121M8.757 15.243l-2.121 2.121" />
-                        </svg>
-                        Genie tip
-                      </button>
-                    </div>
-                    <div class="rounded-2xl bg-white/10 p-4 space-y-2">
-                      <div class="flex items-center justify-between">
-                        <p class="font-semibold text-white">Lanna House</p>
-                        <span class="rounded-full bg-violet-400/20 px-3 py-1 text-xs text-violet-200">Emerging</span>
+                      <div class="rounded-2xl bg-white/10 p-4 space-y-2">
+                        <div class="flex items-center justify-between">
+                          <p class="font-semibold text-white">Lanna House</p>
+                          <span class="rounded-full bg-violet-400/20 px-3 py-1 text-xs text-violet-200">Emerging</span>
+                        </div>
+                        <p class="text-white/65">Patio expansion event series starts in 3 weeks.</p>
+                        <button
+                          type="button"
+                          class="competitor-ai-trigger inline-flex items-center gap-2 rounded-full bg-emerald-500/90 px-3.5 py-1.5 text-xs font-semibold text-night shadow-sm hover:bg-emerald-400 transition"
+                          data-label="Lanna House"
+                        >
+                          <svg xmlns="http://www.w3.org/2000/svg" class="h-3.5 w-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M12 3v3m0 12v3m9-9h-3M6 12H3m15.364 6.364-2.121-2.121M8.757 8.757 6.636 6.636m12.728 0-2.121 2.121M8.757 15.243l-2.121 2.121" />
+                          </svg>
+                          Genie tip
+                        </button>
                       </div>
-                      <p class="text-white/65">Patio expansion event series starts in 3 weeks.</p>
-                      <button
-                        type="button"
-                        class="competitor-ai-trigger inline-flex items-center gap-2 rounded-full bg-emerald-400/90 px-3.5 py-1.5 text-xs font-semibold text-night shadow-sm hover:bg-emerald-300 transition"
-                        data-label="Lanna House"
-                      >
-                        <svg xmlns="http://www.w3.org/2000/svg" class="h-3.5 w-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M12 3v3m0 12v3m9-9h-3M6 12H3m15.364 6.364-2.121-2.121M8.757 8.757 6.636 6.636m12.728 0-2.121 2.121M8.757 15.243l-2.121 2.121" />
-                        </svg>
-                        Genie tip
-                      </button>
-                    </div>
-                    <div class="rounded-2xl bg-white/10 p-4 space-y-2">
-                      <div class="flex items-center justify-between">
-                        <p class="font-semibold text-white">Kin Khao Express</p>
-                        <span class="rounded-full bg-indigo-400/20 px-3 py-1 text-xs text-indigo-200">Steady</span>
+                      <div class="rounded-2xl bg-white/10 p-4 space-y-2">
+                        <div class="flex items-center justify-between">
+                          <p class="font-semibold text-white">Kin Khao Express</p>
+                          <span class="rounded-full bg-indigo-400/20 px-3 py-1 text-xs text-indigo-200">Steady</span>
+                        </div>
+                        <p class="text-white/65">Heat-and-serve kits testing family bundle upsell.</p>
+                        <button
+                          type="button"
+                          class="competitor-ai-trigger inline-flex items-center gap-2 rounded-full bg-emerald-500/90 px-3.5 py-1.5 text-xs font-semibold text-night shadow-sm hover:bg-emerald-400 transition"
+                          data-label="Kin Khao Express"
+                        >
+                          <svg xmlns="http://www.w3.org/2000/svg" class="h-3.5 w-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M12 3v3m0 12v3m9-9h-3M6 12H3m15.364 6.364-2.121-2.121M8.757 8.757 6.636 6.636m12.728 0-2.121 2.121M8.757 15.243l-2.121 2.121" />
+                          </svg>
+                          Genie tip
+                        </button>
                       </div>
-                      <p class="text-white/65">Heat-and-serve kits testing family bundle upsell.</p>
-                      <button
-                        type="button"
-                        class="competitor-ai-trigger inline-flex items-center gap-2 rounded-full bg-emerald-400/90 px-3.5 py-1.5 text-xs font-semibold text-night shadow-sm hover:bg-emerald-300 transition"
-                        data-label="Kin Khao Express"
-                      >
-                        <svg xmlns="http://www.w3.org/2000/svg" class="h-3.5 w-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M12 3v3m0 12v3m9-9h-3M6 12H3m15.364 6.364-2.121-2.121M8.757 8.757 6.636 6.636m12.728 0-2.121 2.121M8.757 15.243l-2.121 2.121" />
-                        </svg>
-                        Genie tip
-                      </button>
                     </div>
                   </div>
-                </div>
 
-                <div class="rounded-3xl bg-white/10 p-7 backdrop-blur-sm space-y-4">
-                  <h3 class="text-xl font-semibold">AI insights / thoughts</h3>
-                  <ul class="space-y-3 text-base text-white/80">
-                    <li class="flex gap-3">
-                      <span class="mt-1 h-2.5 w-2.5 rounded-full bg-rose-400"></span>
-                      Thai Tom's late-night content spikes align with our own midnight orders — stack counter-programming around chef storytelling.
-                    </li>
-                    <li class="flex gap-3">
-                      <span class="mt-1 h-2.5 w-2.5 rounded-full bg-sky-400"></span>
-                      Pinto Bistro is winning brunch press; pivot our narrative to "study sanctuary" to avoid overlap.
-                    </li>
-                    <li class="flex gap-3">
-                      <span class="mt-1 h-2.5 w-2.5 rounded-full bg-emerald-400"></span>
-                      Kin Khao Express heat kits earn 4.8★ — offer our own finals bundle with dine-in pickup to intercept loyalty.
-                    </li>
-                  </ul>
+                  <div class="rounded-3xl bg-white/10 p-7 backdrop-blur-sm space-y-4">
+                    <h3 class="text-xl font-semibold">AI insights / thoughts</h3>
+                    <ul class="space-y-3 text-base text-white/80">
+                      <li class="flex gap-3">
+                        <span class="mt-1 h-2.5 w-2.5 rounded-full bg-rose-400"></span>
+                        Thai Tom's late-night content spikes align with our own midnight orders — stack counter-programming around chef storytelling.
+                      </li>
+                      <li class="flex gap-3">
+                        <span class="mt-1 h-2.5 w-2.5 rounded-full bg-sky-400"></span>
+                        Pinto Bistro is winning brunch press; pivot our narrative to "study sanctuary" to avoid overlap.
+                      </li>
+                      <li class="flex gap-3">
+                        <span class="mt-1 h-2.5 w-2.5 rounded-full bg-emerald-400"></span>
+                        Kin Khao Express heat kits earn 4.8★ — offer our own finals bundle with dine-in pickup to intercept loyalty.
+                      </li>
+                    </ul>
+                  </div>
                 </div>
               </div>
 
@@ -371,17 +377,17 @@
       <p class="text-xs uppercase tracking-wide text-white/50">Genie focus</p>
       <p id="competitor-menu-context" class="mt-1 text-sm font-semibold text-white"></p>
       <div class="mt-4 space-y-2">
-        <button class="competitor-menu-option flex w-full items-center gap-2 rounded-xl bg-white/10 px-3 py-2 text-left text-white/80 hover:bg-white/20 transition" data-action="positioning">
+        <button class="competitor-menu-option flex w-full items-center gap-2 rounded-xl bg-white/10 px-3 py-2 text-left text-white/80 hover:bg-white/20 transition" data-action="refresh">
           <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
             <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.6" d="M4 7h16M4 12h16m-8 5h8" />
           </svg>
-          Refresh positioning
+          Refresh plan
         </button>
         <button class="competitor-menu-option flex w-full items-center gap-2 rounded-xl bg-white/10 px-3 py-2 text-left text-white/80 hover:bg-white/20 transition" data-action="experiment">
           <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
             <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.6" d="M12 6v12m6-6H6" />
           </svg>
-          Draft counter play
+          Draft experiment
         </button>
       </div>
     </div>
@@ -443,7 +449,7 @@
           competitorMenu.classList.add('hidden');
           competitorMenu.style.display = 'none';
           const action = option.dataset.action;
-          alert(action === 'positioning' ? 'Genie drafted a repositioning outline.' : 'Counter play saved to Experiments.');
+          alert(action === 'refresh' ? 'Genie refreshed the competitive plan.' : 'Experiment idea saved to Experiments.');
         });
       });
 

--- a/demo.html
+++ b/demo.html
@@ -29,6 +29,10 @@
       body {
         background: radial-gradient(circle at top, rgba(88, 76, 255, 0.14), transparent 45%), #050508;
       }
+
+      .font-script {
+        font-family: 'Pacifico', 'Allura', cursive !important;
+      }
     </style>
   </head>
   <body class="min-h-screen bg-night text-white font-sans">

--- a/experiments.html
+++ b/experiments.html
@@ -35,6 +35,10 @@
         content: attr(data-placeholder);
         color: rgba(255, 255, 255, 0.4);
       }
+
+      .font-script {
+        font-family: 'Pacifico', 'Allura', cursive !important;
+      }
     </style>
   </head>
   <body class="min-h-screen bg-night text-white font-sans">
@@ -65,10 +69,7 @@
 
         <section class="space-y-10">
           <div class="flex flex-wrap items-center justify-between gap-4">
-            <div>
-              <h2 class="text-2xl font-semibold">Experiment wall</h2>
-              <p class="text-base text-white/70">Stacked by priority · drag-ready layout coming soon</p>
-            </div>
+            <h2 class="text-2xl font-semibold">Experiment wall</h2>
             <button
               id="addExperiment"
               class="inline-flex items-center gap-2 rounded-full bg-white text-black px-5 py-2 text-base font-semibold shadow hover:bg-white/90 transition"
@@ -127,16 +128,18 @@
               data-placeholder="What are we testing?"
             ></div>
           </div>
-          <div class="hidden md:flex h-full items-center justify-center">
-            <svg viewBox="0 0 140 160" class="h-36 w-24 text-white/35">
-              <defs>
-                <marker id="fork-head" markerWidth="6" markerHeight="6" refX="5" refY="3" orient="auto">
-                  <polygon points="0 0, 6 3, 0 6" fill="currentColor"></polygon>
-                </marker>
-              </defs>
-              <path d="M70 12v70" fill="none" stroke="currentColor" stroke-width="6" stroke-linecap="round"></path>
-              <path d="M70 80L35 130" fill="none" stroke="currentColor" stroke-width="6" stroke-linecap="round" marker-end="url(#fork-head)"></path>
-              <path d="M70 80l35 50" fill="none" stroke="currentColor" stroke-width="6" stroke-linecap="round" marker-end="url(#fork-head)"></path>
+          <div class="hidden md:flex flex-col items-center justify-center gap-6 text-white/40">
+            <svg viewBox="0 0 160 60" class="h-14 w-36">
+              <line x1="20" y1="30" x2="130" y2="30" stroke="currentColor" stroke-width="6" stroke-linecap="round"></line>
+              <polygon points="130,20 130,40 148,30" fill="currentColor"></polygon>
+              <text x="20" y="18" font-size="12" fill="currentColor">Plan</text>
+              <text x="148" y="50" font-size="12" text-anchor="end" fill="currentColor">Results</text>
+            </svg>
+            <svg viewBox="0 0 160 60" class="h-14 w-36">
+              <line x1="20" y1="30" x2="130" y2="30" stroke="currentColor" stroke-width="6" stroke-linecap="round"></line>
+              <polygon points="130,20 130,40 148,30" fill="currentColor"></polygon>
+              <text x="20" y="18" font-size="12" fill="currentColor">Plan</text>
+              <text x="148" y="50" font-size="12" text-anchor="end" fill="currentColor">Evidence</text>
             </svg>
           </div>
           <div class="space-y-5">

--- a/finances.html
+++ b/finances.html
@@ -31,6 +31,10 @@
         background: radial-gradient(circle at top left, rgba(251, 191, 36, 0.18), transparent 45%),
           radial-gradient(circle at top right, rgba(249, 115, 22, 0.16), transparent 55%), #050508;
       }
+
+      .font-script {
+        font-family: 'Pacifico', 'Allura', cursive !important;
+      }
     </style>
   </head>
   <body class="min-h-screen bg-night text-white font-sans">

--- a/genie-advisor.html
+++ b/genie-advisor.html
@@ -9,7 +9,7 @@
         theme: {
           extend: {
             fontFamily: {
-              script: ['"Great Vibes"', 'cursive'],
+              script: ['"Pacifico"', '"Allura"', 'cursive'],
               sans: ['"Inter"', 'system-ui', 'sans-serif'],
             },
             colors: {
@@ -24,8 +24,13 @@
     <script src="https://cdn.tailwindcss.com"></script>
     <link
       rel="stylesheet"
-      href="https://fonts.googleapis.com/css2?family=Great+Vibes&family=Inter:wght@300;400;500;600;700&display=swap"
+      href="https://fonts.googleapis.com/css2?family=Allura&family=Inter:wght@300;400;500;600;700&family=Great+Vibes&family=Pacifico&display=swap"
     />
+    <style>
+      .font-script {
+        font-family: 'Pacifico', 'Allura', cursive !important;
+      }
+    </style>
   </head>
   <body class="min-h-screen bg-night text-white font-sans">
     <div class="min-h-screen px-6 md:px-12 pb-16 flex flex-col">

--- a/growth.html
+++ b/growth.html
@@ -31,6 +31,10 @@
         background: radial-gradient(circle at top left, rgba(34, 211, 238, 0.16), transparent 45%),
           radial-gradient(circle at top right, rgba(16, 185, 129, 0.18), transparent 50%), #050508;
       }
+
+      .font-script {
+        font-family: 'Pacifico', 'Allura', cursive !important;
+      }
     </style>
   </head>
   <body class="min-h-screen bg-night text-white font-sans">
@@ -65,7 +69,7 @@
               <button class="tab-trigger rounded-full px-5 py-2 font-semibold bg-white text-black" data-target="growth-strategy">
                 Strategy
               </button>
-              <button class="tab-trigger rounded-full px-5 py-2 font-semibold text-white/75 hover:text-white transition" data-target="growth-dashboard">
+              <button class="tab-trigger rounded-full px-5 py-2 font-semibold text-white/70 hover:text-white transition" data-target="growth-dashboard">
                 Dashboard
               </button>
             </div>
@@ -80,7 +84,7 @@
                 </div>
                 <button
                   type="button"
-                  class="growth-ai-trigger inline-flex items-center gap-2 rounded-full bg-emerald-400 px-5 py-2.5 text-base font-semibold text-night shadow-lg hover:bg-emerald-300 transition"
+                  class="growth-ai-trigger inline-flex items-center gap-2 rounded-full bg-emerald-500 px-5 py-2.5 text-base font-semibold text-night shadow-lg hover:bg-emerald-400 transition"
                   data-label="Strategy overview"
                 >
                   <span class="inline-block h-2 w-2 rounded-full bg-white animate-pulse"></span>
@@ -96,7 +100,7 @@
                     </div>
                     <button
                       type="button"
-                      class="growth-ai-trigger inline-flex items-center gap-2 rounded-full bg-emerald-400/90 px-3.5 py-1.5 text-xs font-semibold text-night shadow-sm hover:bg-emerald-300 transition"
+                      class="growth-ai-trigger inline-flex items-center gap-2 rounded-full bg-emerald-500/90 px-3.5 py-1.5 text-xs font-semibold text-night shadow-sm hover:bg-emerald-400 transition"
                       data-label="Acquisition"
                     >
                       <svg xmlns="http://www.w3.org/2000/svg" class="h-3.5 w-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
@@ -117,7 +121,7 @@
                     </div>
                     <button
                       type="button"
-                      class="growth-ai-trigger inline-flex items-center gap-2 rounded-full bg-emerald-400/90 px-3.5 py-1.5 text-xs font-semibold text-night shadow-sm hover:bg-emerald-300 transition"
+                      class="growth-ai-trigger inline-flex items-center gap-2 rounded-full bg-emerald-500/90 px-3.5 py-1.5 text-xs font-semibold text-night shadow-sm hover:bg-emerald-400 transition"
                       data-label="Conversion"
                     >
                       <svg xmlns="http://www.w3.org/2000/svg" class="h-3.5 w-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
@@ -138,7 +142,7 @@
                     </div>
                     <button
                       type="button"
-                      class="growth-ai-trigger inline-flex items-center gap-2 rounded-full bg-emerald-400/90 px-3.5 py-1.5 text-xs font-semibold text-night shadow-sm hover:bg-emerald-300 transition"
+                      class="growth-ai-trigger inline-flex items-center gap-2 rounded-full bg-emerald-500/90 px-3.5 py-1.5 text-xs font-semibold text-night shadow-sm hover:bg-emerald-400 transition"
                       data-label="Retention"
                     >
                       <svg xmlns="http://www.w3.org/2000/svg" class="h-3.5 w-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
@@ -159,7 +163,7 @@
                     </div>
                     <button
                       type="button"
-                      class="growth-ai-trigger inline-flex items-center gap-2 rounded-full bg-emerald-400/90 px-3.5 py-1.5 text-xs font-semibold text-night shadow-sm hover:bg-emerald-300 transition"
+                      class="growth-ai-trigger inline-flex items-center gap-2 rounded-full bg-emerald-500/90 px-3.5 py-1.5 text-xs font-semibold text-night shadow-sm hover:bg-emerald-400 transition"
                       data-label="Expansion"
                     >
                       <svg xmlns="http://www.w3.org/2000/svg" class="h-3.5 w-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
@@ -347,11 +351,11 @@
       <p class="text-xs uppercase tracking-wide text-white/50">Genie focus</p>
       <p id="growth-menu-context" class="mt-1 text-sm font-semibold text-white"></p>
       <div class="mt-4 space-y-2">
-        <button class="growth-menu-option flex w-full items-center gap-2 rounded-xl bg-white/10 px-3 py-2 text-left text-white/80 hover:bg-white/20 transition" data-action="tune">
+        <button class="growth-menu-option flex w-full items-center gap-2 rounded-xl bg-white/10 px-3 py-2 text-left text-white/80 hover:bg-white/20 transition" data-action="refresh">
           <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.6" d="M4 7h16M4 12h12m-6 5h6" />
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.6" d="M4 7h16M4 12h16m-8 5h8" />
           </svg>
-          Tune plan
+          Refresh plan
         </button>
         <button class="growth-menu-option flex w-full items-center gap-2 rounded-xl bg-white/10 px-3 py-2 text-left text-white/80 hover:bg-white/20 transition" data-action="experiment">
           <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
@@ -419,7 +423,7 @@
           growthMenu.classList.add('hidden');
           growthMenu.style.display = 'none';
           const action = option.dataset.action;
-          alert(action === 'tune' ? 'Genie is tuning the growth plan.' : 'Experiment card drafted in Experiments.');
+          alert(action === 'refresh' ? 'Genie is tuning the growth plan.' : 'Experiment card drafted in Experiments.');
         });
       });
 

--- a/human-advisor.html
+++ b/human-advisor.html
@@ -31,6 +31,10 @@
         background: radial-gradient(circle at top left, rgba(244, 114, 182, 0.18), transparent 45%),
           radial-gradient(circle at top right, rgba(251, 191, 36, 0.16), transparent 55%), #050508;
       }
+
+      .font-script {
+        font-family: 'Pacifico', 'Allura', cursive !important;
+      }
     </style>
   </head>
   <body class="min-h-screen bg-night text-white font-sans">

--- a/inventory.html
+++ b/inventory.html
@@ -31,6 +31,10 @@
         background: radial-gradient(circle at top left, rgba(249, 168, 37, 0.16), transparent 45%),
           radial-gradient(circle at top right, rgba(34, 197, 94, 0.16), transparent 55%), #050508;
       }
+
+      .font-script {
+        font-family: 'Pacifico', 'Allura', cursive !important;
+      }
     </style>
   </head>
   <body class="min-h-screen bg-night text-white font-sans">

--- a/marketing.html
+++ b/marketing.html
@@ -31,6 +31,10 @@
         background: radial-gradient(circle at top left, rgba(244, 114, 182, 0.18), transparent 45%),
           radial-gradient(circle at top right, rgba(56, 189, 248, 0.14), transparent 50%), #050508;
       }
+
+      .font-script {
+        font-family: 'Pacifico', 'Allura', cursive !important;
+      }
     </style>
   </head>
   <body class="min-h-screen bg-night text-white font-sans">
@@ -56,7 +60,7 @@
       <main class="flex-1 py-10 flex flex-col gap-12">
         <section class="max-w-4xl">
           <h1 class="text-5xl md:text-6xl font-light">Marketing</h1>
-          <p class="mt-3 text-lg text-white/70">Optimisze your outreach.</p>
+          <p class="mt-3 text-lg text-white/70">Optimize your outreach.</p>
         </section>
 
         <section class="space-y-12">
@@ -65,7 +69,7 @@
               <button class="tab-trigger rounded-full px-5 py-2 font-semibold bg-white text-black" data-target="marketing-strategy">
                 Strategy
               </button>
-              <button class="tab-trigger rounded-full px-5 py-2 font-semibold text-white/75 hover:text-white transition" data-target="marketing-dashboard">
+              <button class="tab-trigger rounded-full px-5 py-2 font-semibold text-white/70 hover:text-white transition" data-target="marketing-dashboard">
                 Dashboard
               </button>
             </div>
@@ -80,7 +84,7 @@
                 </div>
                 <button
                   type="button"
-                  class="ai-trigger inline-flex items-center gap-2 rounded-full bg-emerald-400 px-5 py-2.5 text-base font-semibold text-night shadow-lg hover:bg-emerald-300 transition"
+                  class="ai-trigger inline-flex items-center gap-2 rounded-full bg-emerald-500 px-5 py-2.5 text-base font-semibold text-night shadow-lg hover:bg-emerald-400 transition"
                   data-marketing-ai="overview"
                   data-label="Strategy overview"
                 >
@@ -97,7 +101,7 @@
                     </div>
                     <button
                       type="button"
-                      class="ai-trigger inline-flex items-center gap-2 rounded-full bg-emerald-400/90 px-3.5 py-1.5 text-xs font-semibold text-night shadow-sm hover:bg-emerald-300 transition"
+                      class="ai-trigger inline-flex items-center gap-2 rounded-full bg-emerald-500/90 px-3.5 py-1.5 text-xs font-semibold text-night shadow-sm hover:bg-emerald-400 transition"
                       data-marketing-ai="social"
                       data-label="Social media"
                     >
@@ -119,7 +123,7 @@
                     </div>
                     <button
                       type="button"
-                      class="ai-trigger inline-flex items-center gap-2 rounded-full bg-emerald-400/90 px-3.5 py-1.5 text-xs font-semibold text-night shadow-sm hover:bg-emerald-300 transition"
+                      class="ai-trigger inline-flex items-center gap-2 rounded-full bg-emerald-500/90 px-3.5 py-1.5 text-xs font-semibold text-night shadow-sm hover:bg-emerald-400 transition"
                       data-marketing-ai="community"
                       data-label="Community"
                     >
@@ -141,7 +145,7 @@
                     </div>
                     <button
                       type="button"
-                      class="ai-trigger inline-flex items-center gap-2 rounded-full bg-emerald-400/90 px-3.5 py-1.5 text-xs font-semibold text-night shadow-sm hover:bg-emerald-300 transition"
+                      class="ai-trigger inline-flex items-center gap-2 rounded-full bg-emerald-500/90 px-3.5 py-1.5 text-xs font-semibold text-night shadow-sm hover:bg-emerald-400 transition"
                       data-marketing-ai="loyalty"
                       data-label="Loyalty"
                     >
@@ -163,7 +167,7 @@
                     </div>
                     <button
                       type="button"
-                      class="ai-trigger inline-flex items-center gap-2 rounded-full bg-emerald-400/90 px-3.5 py-1.5 text-xs font-semibold text-night shadow-sm hover:bg-emerald-300 transition"
+                      class="ai-trigger inline-flex items-center gap-2 rounded-full bg-emerald-500/90 px-3.5 py-1.5 text-xs font-semibold text-night shadow-sm hover:bg-emerald-400 transition"
                       data-marketing-ai="partnerships"
                       data-label="Partnerships"
                     >
@@ -384,7 +388,7 @@
       <p class="text-xs uppercase tracking-wide text-white/50">Genie focus</p>
       <p id="marketing-menu-context" class="mt-1 text-sm font-semibold text-white"></p>
       <div class="mt-4 space-y-2">
-        <button class="menu-option flex w-full items-center gap-2 rounded-xl bg-white/10 px-3 py-2 text-left text-white/80 hover:bg-white/20 transition" data-action="change">
+        <button class="menu-option flex w-full items-center gap-2 rounded-xl bg-white/10 px-3 py-2 text-left text-white/80 hover:bg-white/20 transition" data-action="refresh">
           <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
             <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.6" d="M4 7h16M4 12h16m-8 5h8" />
           </svg>
@@ -456,7 +460,7 @@
           marketingMenu.classList.add('hidden');
           marketingMenu.style.display = 'none';
           const action = option.dataset.action;
-          alert(action === 'change' ? 'Genie is tuning the outreach plan.' : 'Experiment idea saved to Experiments.');
+          alert(action === 'refresh' ? 'Genie is tuning the outreach plan.' : 'Experiment idea saved to Experiments.');
         });
       });
 


### PR DESCRIPTION
## Summary
- standardize the Pacifico script styling across the demo and app pages and tidy the Copilot header copy
- darken the Genie tip buttons, align their menu actions, and fix the marketing hero copy and dashboard toggle readability
- refresh the competitors and experiments layouts with improved watchlist/insights columns, renamed stats, and clearer plan arrows

## Testing
- Not run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68d18f37ccc4832fa84b7121a8762a53