### PR TITLE
Adjust Genie interactions and layout

### DIFF
--- a/ai-companion.html
+++ b/ai-companion.html
@@ -53,7 +53,7 @@
         <div class="text-right text-sm text-white/60">Suit and Thai · Always on</div>
       </header>
 
-      <main class="flex-1 px-6 md:px-12 pb-10">
+      <main class="flex-1 px-6 md:px-12 pb-10 mt-8 md:mt-10">
         <section class="grid gap-8 lg:grid-cols-[0.45fr,1.55fr]">
           <aside class="rounded-3xl bg-white/10 p-6 backdrop-blur-sm space-y-5 shadow-[0_20px_45px_-30px_rgba(56,189,248,0.55)] ring-1 ring-white/10">
             <div>

--- a/competitors.html
+++ b/competitors.html
@@ -181,7 +181,7 @@
 
             <div class="grid gap-6 lg:grid-cols-[1.1fr,0.9fr]">
               <div class="space-y-6">
-                <div class="grid gap-6 xl:grid-cols-[1.1fr,0.9fr]">
+                <div class="grid w-full gap-6 lg:grid-cols-2 xl:grid-cols-[minmax(0,1.1fr)_minmax(0,0.9fr)]">
                   <div class="rounded-3xl bg-white/10 p-7 backdrop-blur-sm space-y-5">
                     <h3 class="text-xl font-semibold">Competitor watchlist</h3>
                     <div class="grid gap-4 sm:grid-cols-2 text-base text-white/80">
@@ -257,7 +257,7 @@
                   </div>
 
                   <div class="rounded-3xl bg-white/10 p-7 backdrop-blur-sm space-y-4">
-                    <h3 class="text-xl font-semibold">AI insights / thoughts</h3>
+                    <h3 class="text-xl font-semibold">AI insights</h3>
                     <ul class="space-y-3 text-base text-white/80">
                       <li class="flex gap-3">
                         <span class="mt-1 h-2.5 w-2.5 rounded-full bg-rose-400"></span>
@@ -377,15 +377,21 @@
       <p class="text-xs uppercase tracking-wide text-white/50">Genie focus</p>
       <p id="competitor-menu-context" class="mt-1 text-sm font-semibold text-white"></p>
       <div class="mt-4 space-y-2">
-        <button class="competitor-menu-option flex w-full items-center gap-2 rounded-xl bg-white/10 px-3 py-2 text-left text-white/80 hover:bg-white/20 transition" data-action="refresh">
+        <button class="competitor-menu-option flex w-full items-center gap-2 rounded-xl bg-white/10 px-3 py-2 text-left text-white/80 hover:bg-white/20 transition" data-action="learn">
           <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.6" d="M4 7h16M4 12h16m-8 5h8" />
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.6" d="M5 7h14M5 12h14M5 17h14" />
           </svg>
-          Refresh plan
+          Learn more
+        </button>
+        <button class="competitor-menu-option flex w-full items-center gap-2 rounded-xl bg-white/10 px-3 py-2 text-left text-white/80 hover:bg-white/20 transition" data-action="add">
+          <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.6" d="M12 5v14m7-7H5" />
+          </svg>
+          Add to strategy
         </button>
         <button class="competitor-menu-option flex w-full items-center gap-2 rounded-xl bg-white/10 px-3 py-2 text-left text-white/80 hover:bg-white/20 transition" data-action="experiment">
           <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.6" d="M12 6v12m6-6H6" />
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.6" d="M7 4h10m-8 0v5l-3 6h12l-3-6V4" />
           </svg>
           Draft experiment
         </button>
@@ -414,11 +420,43 @@
       const competitorMenuContext = document.getElementById('competitor-menu-context');
       const competitorTriggers = document.querySelectorAll('.competitor-ai-trigger');
       let competitorActiveTrigger = null;
+      let competitorLastCoords = null;
 
-      function positionCompetitorMenu(trigger) {
-        const rect = trigger.getBoundingClientRect();
-        competitorMenu.style.top = `${rect.bottom + window.scrollY + 8}px`;
-        competitorMenu.style.left = `${Math.min(rect.left + window.scrollX, window.innerWidth - competitorMenu.offsetWidth - 16)}px`;
+      function positionCompetitorMenu(coords) {
+        const offset = 12;
+        requestAnimationFrame(() => {
+          const { innerWidth, innerHeight, scrollX, scrollY } = window;
+          const menuWidth = competitorMenu.offsetWidth;
+          const menuHeight = competitorMenu.offsetHeight;
+
+          let left = coords.x + scrollX - menuWidth / 2;
+          let top = coords.y + scrollY + offset;
+
+          const minLeft = scrollX + 16;
+          const maxLeft = scrollX + innerWidth - menuWidth - 16;
+          left = Math.min(Math.max(left, minLeft), maxLeft);
+
+          const minTop = scrollY + 16;
+          const maxTop = scrollY + innerHeight - menuHeight - 16;
+          top = Math.min(Math.max(top, minTop), maxTop);
+
+          competitorMenu.style.left = `${left}px`;
+          competitorMenu.style.top = `${top}px`;
+        });
+      }
+
+      function showCompetitorMenu(coords) {
+        competitorMenu.classList.remove('hidden');
+        competitorMenu.style.display = 'block';
+        competitorLastCoords = coords;
+        positionCompetitorMenu(coords);
+      }
+
+      function hideCompetitorMenu() {
+        competitorMenu.classList.add('hidden');
+        competitorMenu.style.display = 'none';
+        competitorActiveTrigger = null;
+        competitorLastCoords = null;
       }
 
       competitorTriggers.forEach((trigger) => {
@@ -427,35 +465,33 @@
           const label = trigger.dataset.label || 'Landscape';
           competitorMenuContext.textContent = label;
           competitorActiveTrigger = trigger;
-          competitorMenu.classList.remove('hidden');
-          competitorMenu.style.display = 'block';
-          requestAnimationFrame(() => {
-            positionCompetitorMenu(trigger);
-          });
+          showCompetitorMenu({ x: event.clientX, y: event.clientY });
         });
       });
 
       document.addEventListener('click', (event) => {
         if (!competitorMenu.contains(event.target)) {
-          competitorMenu.classList.add('hidden');
-          competitorMenu.style.display = 'none';
-          competitorActiveTrigger = null;
+          hideCompetitorMenu();
         }
       });
 
       const competitorOptions = document.querySelectorAll('.competitor-menu-option');
       competitorOptions.forEach((option) => {
         option.addEventListener('click', () => {
-          competitorMenu.classList.add('hidden');
-          competitorMenu.style.display = 'none';
           const action = option.dataset.action;
-          alert(action === 'refresh' ? 'Genie refreshed the competitive plan.' : 'Experiment idea saved to Experiments.');
+          const messages = {
+            learn: 'Genie is pulling a deeper read on that signal.',
+            add: 'Added to the competitive strategy board.',
+            experiment: 'Experiment idea saved to Experiments.',
+          };
+          alert(messages[action] || 'Genie is thinking...');
+          hideCompetitorMenu();
         });
       });
 
       window.addEventListener('resize', () => {
-        if (!competitorMenu.classList.contains('hidden') && competitorActiveTrigger) {
-          positionCompetitorMenu(competitorActiveTrigger);
+        if (!competitorMenu.classList.contains('hidden') && competitorLastCoords) {
+          positionCompetitorMenu(competitorLastCoords);
         }
       });
     </script>

--- a/growth.html
+++ b/growth.html
@@ -212,7 +212,7 @@
 
               <aside class="rounded-3xl bg-white/10 p-8 backdrop-blur-sm space-y-5">
                 <div class="flex items-center justify-between">
-                  <h3 class="text-xl font-semibold">AI notes</h3>
+                  <h3 class="text-xl font-semibold">AI insights</h3>
                   <span class="inline-flex items-center gap-2 rounded-full bg-white/10 px-3.5 py-1.5 text-sm text-white/75">
                     <span class="h-2 w-2 rounded-full bg-emerald-400"></span>
                     Synced
@@ -351,15 +351,21 @@
       <p class="text-xs uppercase tracking-wide text-white/50">Genie focus</p>
       <p id="growth-menu-context" class="mt-1 text-sm font-semibold text-white"></p>
       <div class="mt-4 space-y-2">
-        <button class="growth-menu-option flex w-full items-center gap-2 rounded-xl bg-white/10 px-3 py-2 text-left text-white/80 hover:bg-white/20 transition" data-action="refresh">
+        <button class="growth-menu-option flex w-full items-center gap-2 rounded-xl bg-white/10 px-3 py-2 text-left text-white/80 hover:bg-white/20 transition" data-action="learn">
           <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.6" d="M4 7h16M4 12h16m-8 5h8" />
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.6" d="M5 7h14M5 12h14M5 17h14" />
           </svg>
-          Refresh plan
+          Learn more
+        </button>
+        <button class="growth-menu-option flex w-full items-center gap-2 rounded-xl bg-white/10 px-3 py-2 text-left text-white/80 hover:bg-white/20 transition" data-action="add">
+          <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.6" d="M12 5v14m7-7H5" />
+          </svg>
+          Add to strategy
         </button>
         <button class="growth-menu-option flex w-full items-center gap-2 rounded-xl bg-white/10 px-3 py-2 text-left text-white/80 hover:bg-white/20 transition" data-action="experiment">
           <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.6" d="M12 6v12m6-6H6" />
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.6" d="M7 4h10m-8 0v5l-3 6h12l-3-6V4" />
           </svg>
           Draft experiment
         </button>
@@ -388,11 +394,43 @@
       const growthMenuContext = document.getElementById('growth-menu-context');
       const growthTriggers = document.querySelectorAll('.growth-ai-trigger');
       let growthActiveTrigger = null;
+      let growthLastCoords = null;
 
-      function positionGrowthMenu(trigger) {
-        const rect = trigger.getBoundingClientRect();
-        growthMenu.style.top = `${rect.bottom + window.scrollY + 8}px`;
-        growthMenu.style.left = `${Math.min(rect.left + window.scrollX, window.innerWidth - growthMenu.offsetWidth - 16)}px`;
+      function positionGrowthMenu(coords) {
+        const offset = 12;
+        requestAnimationFrame(() => {
+          const { innerWidth, innerHeight, scrollX, scrollY } = window;
+          const menuWidth = growthMenu.offsetWidth;
+          const menuHeight = growthMenu.offsetHeight;
+
+          let left = coords.x + scrollX - menuWidth / 2;
+          let top = coords.y + scrollY + offset;
+
+          const minLeft = scrollX + 16;
+          const maxLeft = scrollX + innerWidth - menuWidth - 16;
+          left = Math.min(Math.max(left, minLeft), maxLeft);
+
+          const minTop = scrollY + 16;
+          const maxTop = scrollY + innerHeight - menuHeight - 16;
+          top = Math.min(Math.max(top, minTop), maxTop);
+
+          growthMenu.style.left = `${left}px`;
+          growthMenu.style.top = `${top}px`;
+        });
+      }
+
+      function showGrowthMenu(coords) {
+        growthMenu.classList.remove('hidden');
+        growthMenu.style.display = 'block';
+        growthLastCoords = coords;
+        positionGrowthMenu(coords);
+      }
+
+      function hideGrowthMenu() {
+        growthMenu.classList.add('hidden');
+        growthMenu.style.display = 'none';
+        growthActiveTrigger = null;
+        growthLastCoords = null;
       }
 
       growthTriggers.forEach((trigger) => {
@@ -401,35 +439,33 @@
           const label = trigger.dataset.label || 'Strategy';
           growthMenuContext.textContent = label;
           growthActiveTrigger = trigger;
-          growthMenu.classList.remove('hidden');
-          growthMenu.style.display = 'block';
-          requestAnimationFrame(() => {
-            positionGrowthMenu(trigger);
-          });
+          showGrowthMenu({ x: event.clientX, y: event.clientY });
         });
       });
 
       document.addEventListener('click', (event) => {
         if (!growthMenu.contains(event.target)) {
-          growthMenu.classList.add('hidden');
-          growthMenu.style.display = 'none';
-          growthActiveTrigger = null;
+          hideGrowthMenu();
         }
       });
 
       const growthOptions = document.querySelectorAll('.growth-menu-option');
       growthOptions.forEach((option) => {
         option.addEventListener('click', () => {
-          growthMenu.classList.add('hidden');
-          growthMenu.style.display = 'none';
           const action = option.dataset.action;
-          alert(action === 'refresh' ? 'Genie is tuning the growth plan.' : 'Experiment card drafted in Experiments.');
+          const messages = {
+            learn: 'Genie is pulling more signal detail.',
+            add: 'Added to your growth strategy plan.',
+            experiment: 'Experiment card drafted in Experiments.',
+          };
+          alert(messages[action] || 'Genie is thinking...');
+          hideGrowthMenu();
         });
       });
 
       window.addEventListener('resize', () => {
-        if (!growthMenu.classList.contains('hidden') && growthActiveTrigger) {
-          positionGrowthMenu(growthActiveTrigger);
+        if (!growthMenu.classList.contains('hidden') && growthLastCoords) {
+          positionGrowthMenu(growthLastCoords);
         }
       });
     </script>

--- a/marketing.html
+++ b/marketing.html
@@ -189,7 +189,7 @@
               <div class="space-y-6">
                 <div class="rounded-3xl bg-white/10 p-7 backdrop-blur-sm">
                   <div class="flex items-center justify-between">
-                    <h3 class="text-xl font-semibold">AI insights / thoughts</h3>
+                    <h3 class="text-xl font-semibold">AI insights</h3>
                     <span class="inline-flex items-center gap-2 rounded-full bg-white/10 px-3.5 py-1.5 text-sm text-white/75">
                       <span class="h-2 w-2 rounded-full bg-emerald-400"></span>
                       Synced 2m ago
@@ -388,15 +388,21 @@
       <p class="text-xs uppercase tracking-wide text-white/50">Genie focus</p>
       <p id="marketing-menu-context" class="mt-1 text-sm font-semibold text-white"></p>
       <div class="mt-4 space-y-2">
-        <button class="menu-option flex w-full items-center gap-2 rounded-xl bg-white/10 px-3 py-2 text-left text-white/80 hover:bg-white/20 transition" data-action="refresh">
+        <button class="menu-option flex w-full items-center gap-2 rounded-xl bg-white/10 px-3 py-2 text-left text-white/80 hover:bg-white/20 transition" data-action="learn">
           <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.6" d="M4 7h16M4 12h16m-8 5h8" />
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.6" d="M5 7h14M5 12h14M5 17h14" />
           </svg>
-          Refresh plan
+          Learn more
+        </button>
+        <button class="menu-option flex w-full items-center gap-2 rounded-xl bg-white/10 px-3 py-2 text-left text-white/80 hover:bg-white/20 transition" data-action="add">
+          <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.6" d="M12 5v14m7-7H5" />
+          </svg>
+          Add to strategy
         </button>
         <button class="menu-option flex w-full items-center gap-2 rounded-xl bg-white/10 px-3 py-2 text-left text-white/80 hover:bg-white/20 transition" data-action="experiment">
           <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.6" d="M12 6v12m6-6H6" />
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.6" d="M7 4h10m-8 0v5l-3 6h12l-3-6V4" />
           </svg>
           Draft experiment
         </button>
@@ -425,11 +431,43 @@
       const marketingContext = document.getElementById('marketing-menu-context');
       const marketingTriggers = document.querySelectorAll('.ai-trigger');
       let marketingActiveTrigger = null;
+      let marketingLastCoords = null;
 
-      function positionMenu(trigger) {
-        const rect = trigger.getBoundingClientRect();
-        marketingMenu.style.top = `${rect.bottom + window.scrollY + 8}px`;
-        marketingMenu.style.left = `${Math.min(rect.left + window.scrollX, window.innerWidth - marketingMenu.offsetWidth - 16)}px`;
+      function positionMenuAtCursor(menu, coords) {
+        const offset = 12;
+        requestAnimationFrame(() => {
+          const { innerWidth, innerHeight, scrollX, scrollY } = window;
+          const menuWidth = menu.offsetWidth;
+          const menuHeight = menu.offsetHeight;
+
+          let left = coords.x + scrollX - menuWidth / 2;
+          let top = coords.y + scrollY + offset;
+
+          const minLeft = scrollX + 16;
+          const maxLeft = scrollX + innerWidth - menuWidth - 16;
+          left = Math.min(Math.max(left, minLeft), maxLeft);
+
+          const minTop = scrollY + 16;
+          const maxTop = scrollY + innerHeight - menuHeight - 16;
+          top = Math.min(Math.max(top, minTop), maxTop);
+
+          menu.style.left = `${left}px`;
+          menu.style.top = `${top}px`;
+        });
+      }
+
+      function showMarketingMenu(coords) {
+        marketingMenu.classList.remove('hidden');
+        marketingMenu.style.display = 'block';
+        marketingLastCoords = coords;
+        positionMenuAtCursor(marketingMenu, coords);
+      }
+
+      function hideMarketingMenu() {
+        marketingMenu.classList.add('hidden');
+        marketingMenu.style.display = 'none';
+        marketingActiveTrigger = null;
+        marketingLastCoords = null;
       }
 
       marketingTriggers.forEach((trigger) => {
@@ -438,35 +476,33 @@
           const label = trigger.dataset.label || 'Strategy';
           marketingContext.textContent = label;
           marketingActiveTrigger = trigger;
-          marketingMenu.classList.remove('hidden');
-          marketingMenu.style.display = 'block';
-          requestAnimationFrame(() => {
-            positionMenu(trigger);
-          });
+          showMarketingMenu({ x: event.clientX, y: event.clientY });
         });
       });
 
       document.addEventListener('click', (event) => {
         if (!marketingMenu.contains(event.target)) {
-          marketingMenu.classList.add('hidden');
-          marketingMenu.style.display = 'none';
-          marketingActiveTrigger = null;
+          hideMarketingMenu();
         }
       });
 
       const marketingOptions = document.querySelectorAll('#marketing-ai-menu .menu-option');
       marketingOptions.forEach((option) => {
         option.addEventListener('click', () => {
-          marketingMenu.classList.add('hidden');
-          marketingMenu.style.display = 'none';
           const action = option.dataset.action;
-          alert(action === 'refresh' ? 'Genie is tuning the outreach plan.' : 'Experiment idea saved to Experiments.');
+          const messages = {
+            learn: 'Genie is pulling more context for you.',
+            add: 'Added to your strategy queue.',
+            experiment: 'Experiment idea saved to Experiments.',
+          };
+          alert(messages[action] || 'Genie is thinking...');
+          hideMarketingMenu();
         });
       });
 
       window.addEventListener('resize', () => {
-        if (!marketingMenu.classList.contains('hidden') && marketingActiveTrigger) {
-          positionMenu(marketingActiveTrigger);
+        if (!marketingMenu.classList.contains('hidden') && marketingLastCoords) {
+          positionMenuAtCursor(marketingMenu, marketingLastCoords);
         }
       });
     </script>


### PR DESCRIPTION
## Summary
- add breathing room below the Genie wordmark on the copilot view so the context panel no longer overlaps it
- restyle and relocate every Genie tip menu so it opens at the click position with Learn more, Add to strategy, and Draft experiment actions
- standardize "AI insights" copy and expand the competitor watchlist grid to use the full width

## Testing
- Not run (static site; no automated tests provided)


------
https://chatgpt.com/codex/tasks/task_e_68d19413c7e0832fad21a73b7e1965c6